### PR TITLE
お気に入り機能実装

### DIFF
--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -1,0 +1,17 @@
+class FavoritesController < ApplicationController
+  def create
+    current_user.favorite(@recipe)
+    redirect_back(fallback_location: @recipe)
+  end
+
+  def destroy
+    current_user.unfavorite(@recipe)
+    redirect_back(fallback_location: @recipe)
+  end
+
+  
+  private
+  def set_recipe
+    @recipe = Recipe.find(params[:recipe_id])
+  end
+end

--- a/app/helpers/favorites_helper.rb
+++ b/app/helpers/favorites_helper.rb
@@ -1,0 +1,2 @@
+module FavoritesHelper
+end

--- a/app/models/favorite.rb
+++ b/app/models/favorite.rb
@@ -1,0 +1,7 @@
+class Favorite < ApplicationRecord
+  belongs_to :user
+  belongs_to :recipe
+
+  # 同じユーザー・レシピの組み合わせは一意
+  validates :user_id, uniqueness: { scope: :recipe_id }
+end

--- a/app/models/recipe.rb
+++ b/app/models/recipe.rb
@@ -65,7 +65,9 @@ class Recipe < ApplicationRecord
 
   # お気に入り関連のリレーション追加
   has_many :favorites, dependent: :destroy
-  has_many :favorited_by, through: :favorites, source: :user
+  #中間テーブルを経由して関連付け
+  has_many :favorited_by, through: :favorites, source: :user 
+  
   
   # お気に入り数を取得
   def favorite_count

--- a/app/models/recipe.rb
+++ b/app/models/recipe.rb
@@ -62,5 +62,21 @@ class Recipe < ApplicationRecord
   #     errors.add(:image, 'は5MB以下にしてください')
   #   end
   # end
+
+  # お気に入り関連のリレーション追加
+  has_many :favorites, dependent: :destroy
+  has_many :favorited_by, through: :favorites, source: :user
+  
+  # お気に入り数を取得
+  def favorite_count
+    favorites.count
+  end
+  
+  # 人気順のスコープ（お気に入り数順）
+  scope :popular, -> { 
+    left_joins(:favorites)
+      .group(:id)
+      .order('COUNT(favorites.id) DESC')
+  }
 end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -20,5 +20,23 @@ class User < ApplicationRecord
     name.presence || "匿名ユーザー"
   end
   
-  # 後で追加予定のリレーション# has_many :recipes, dependent: :destroy
+  # お気に入り関連のリレーション追加
+  has_many :favorites, dependent: :destroy
+  has_many :favorite_recipes, through: :favorites, source: :recipe
+  
+  # お気に入りかどうかを判定するメソッド
+  def favorited?(recipe)
+    favorites.exists?(recipe: recipe)
+  end
+  
+  # お気に入りに追加
+  def favorite(recipe)
+    favorites.find_or_create_by(recipe: recipe)
+  end
+  
+  # お気に入りから削除
+  def unfavorite(recipe)
+    favorites.find_by(recipe: recipe)&.destroy
+  end
+
 end

--- a/app/views/favorites/create.html.erb
+++ b/app/views/favorites/create.html.erb
@@ -1,0 +1,2 @@
+<h1>Favorites#create</h1>
+<p>Find me in app/views/favorites/create.html.erb</p>

--- a/app/views/favorites/destroy.html.erb
+++ b/app/views/favorites/destroy.html.erb
@@ -1,0 +1,2 @@
+<h1>Favorites#destroy</h1>
+<p>Find me in app/views/favorites/destroy.html.erb</p>

--- a/app/views/recipes/index.html.erb
+++ b/app/views/recipes/index.html.erb
@@ -1,8 +1,11 @@
 <!-- ヒーローセクション -->
-<div class="hero-section text-center py-5 mb-5" style="background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); color: white; border-radius: 20px;">
+<div class="hero-section text-center py-5 mb-5"
+     style="background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            color: white; border-radius: 20px;">
   <div class="container">
     <h1 class="display-4 fw-bold">🍳 CookShare</h1>
     <p class="lead mb-4">あなたの美味しいレシピを世界と共有しよう</p>
+
     <div class="row text-center mb-4">
       <div class="col-md-4">
         <h3><%= @total_recipes %></h3>
@@ -17,6 +20,7 @@
         <p>今日の日付</p>
       </div>
     </div>
+
     <div class="mt-4">
       <% if user_signed_in? %>
         <%= link_to "レシピを投稿", new_recipe_path, class: "btn btn-warning btn-lg me-3" %>
@@ -26,107 +30,66 @@
         <%= link_to "レシピを見る", "#recipes-section", class: "btn btn-outline-light btn-lg" %>
       <% end %>
     </div>
+
   </div>
 </div>
 
 <!-- 検索セクション -->
-<div class="search-section mb-5">
-  <div class="card shadow-sm">
-    <div class="card-body">
-      <%= form_with url: recipes_path, method: :get, local: true, class: "d-flex gap-3" do |f| %>
-        <div class="flex-grow-1">
-          <%= f.text_field :search, placeholder: "レシピを検索...", 
-                          class: "form-control form-control-lg",
-                          value: params[:search] %>
-        </div>
-        <div>
-          <%= f.select :cooking_time, 
-                      options_for_select([
-                        ['調理時間を選択', ''],
-                        ['15分以内', '15'],
-                        ['30分以内', '30'],
-                        ['1時間以内', '60']
-                      ], params[:cooking_time]), 
-                      {}, { class: "form-select form-select-lg" } %>
-        </div>
-        <div>
-          <%= f.submit "検索", class: "btn btn-primary btn-lg" %>
-        </div>
-      <% end %>
-    </div>
-  </div>
-</div>
+<% if @recipes.present? %>
+<div class="row">
+  <% @recipes.each do |recipe| %>
+    <div class="col-lg-4 col-md-6 mb-4">
+      <div class="card recipe-card h-100 shadow-sm">
 
-<!-- レシピ一覧セクション -->
-<div id="recipes-section" class="mb-5">
-  <div class="d-flex justify-content-between align-items-center mb-4">
-    <h2 class="h4 mb-0">
-      <%= params[:search].present? ? "検索結果" : "最新のレシピ" %>
-      <span class="text-muted">(<%= @recipes.total_count %>件)</span>
-    </h2>
-    <div class="dropdown">
-      <button class="btn btn-outline-secondary dropdown-toggle" type="button" data-bs-toggle="dropdown">
-        並び順
-      </button>
-      <ul class="dropdown-menu">
-        <li><%= link_to "新着順", recipes_path(sort: "recent"), class: "dropdown-item" %></li>
-        <li><%= link_to "調理時間順", recipes_path(sort: "cooking_time"), class: "dropdown-item" %></li>
-        <li><%= link_to "人気順", recipes_path(sort: "popular"), class: "dropdown-item" %></li>
-      </ul>
-    </div>
-  </div>
-
-  <% if @recipes.any? %>
-    <div class="row">
-      <% @recipes.each do |recipe| %>
-        <div class="col-lg-4 col-md-6 mb-4">
-          <div class="card recipe-card h-100 shadow-sm">
-            <div class="recipe-image-container">
-              <% if recipe.image.present? %>
-                <%= image_tag recipe.image, class: "card-img-top recipe-card-image", alt: recipe.title %>
-              <% else %>
-                <div class="card-img-top bg-light d-flex align-items-center justify-content-center recipe-card-image">
-                  <span class="text-muted fs-1">🍽️</span>
-                </div>
-              <% end %>
-              <div class="recipe-overlay">
-                <%= link_to "詳細を見る", recipe_path(recipe), class: "btn btn-light btn-sm" %>
-              </div>
+        <!-- 画像＋お気に入りオーバーレイ -->
+        <div class="recipe-image-container position-relative">
+          <% if recipe.image.attached? %>
+            <%= image_tag recipe.image, class: "card-img-top recipe-card-image", alt: recipe.title %>
+          <% else %>
+            <div class="card-img-top bg-light d-flex align-items-center justify-content-center recipe-placeholder">
+              <span class="text-muted fs-1">🍽️</span>
             </div>
-            
-            <div class="card-body d-flex flex-column">
-              <h5 class="card-title">
-                <%= link_to recipe.title, recipe_path(recipe), 
-                           class: "text-decoration-none text-dark" %>
-              </h5>
-              
-              <p class="card-text text-muted flex-grow-1">
-                <%= truncate(recipe.description, length: 80) %>
-              </p>
-              
-              <div class="recipe-meta mb-3">
-                <small class="text-muted">
-                  <i class="bi bi-clock"></i> <%= recipe.cooking_time %>分 |
-                  <i class="bi bi-people"></i> <%= recipe.servings %>人分 |
-                  <i class="bi bi-person"></i> <%= recipe.user.name %>
-                </small>
-              </div>
-              
-              <div class="recipe-stats">
-                <span class="badge bg-primary me-1">材料 <%= recipe.ingredients.count %>種</span>
-                <span class="badge bg-success">手順 <%= recipe.steps.count %>個</span>
-              </div>
-            </div>
+          <% end %>
+          <!-- お気に入りボタン（右上） -->
+          <div class="position-absolute top-0 end-0 p-2">
+            <%= render 'shared/favorite_button', recipe: recipe %>
           </div>
         </div>
-      <% end %>
+
+        <!-- カード本文 -->
+        <div class="card-body d-flex flex-column">
+          <h5 class="card-title">
+            <%= link_to truncate(recipe.title, length: 30), recipe_path(recipe),
+                       class: "text-decoration-none text-dark" %>
+          </h5>
+
+          <p class="card-text text-muted flex-grow-1">
+            <%= truncate(recipe.description, length: 80) %>
+          </p>
+
+          <div class="recipe-meta mb-3">
+            <small class="text-muted">
+              ⏰ <%= recipe.cooking_time %>分 |
+              👥 <%= recipe.servings %>人分 |
+              👨‍🍳 <%= recipe.user.name %>
+            </small>
+          </div>
+
+          <div class="d-flex justify-content-between align-items-center">
+            <%= link_to "詳細を見る", recipe_path(recipe), class: "btn btn-primary btn-sm" %>
+            <small class="text-muted"><%= time_ago_in_words(recipe.created_at) %>前</small>
+          </div>
+        </div>
+      </div>
     </div>
+  <% end %>
+</div>
 
     <!-- ページネーション -->
-    <div class="d-flex justify-content-center mt-4">
+  <div class="d-flex justify-content-center mt-4">
       <%= paginate @recipes %>
     </div>
-  <% else %>
+    <% else %>
     <div class="text-center py-5">
       <div class="mb-4">
         <span style="font-size: 4rem;">🔍</span>
@@ -135,5 +98,5 @@
       <p class="text-muted">検索条件を変更して再度お試しください</p>
       <%= link_to "すべてのレシピを見る", recipes_path, class: "btn btn-primary" %>
     </div>
-  <% end %>
-</div>
+    <% end %>
+  </div>

--- a/app/views/shared/_favorite_button.html.erb
+++ b/app/views/shared/_favorite_button.html.erb
@@ -3,7 +3,7 @@
     <% if current_user.favorited?(recipe) %>
       <%= link_to recipe_favorite_path(recipe), 
                   class: "btn btn-outline-danger btn-sm",
-                  data: { turbo_method: :delete } do %>
+                  data: { turbo_method: "delete" } do %>
         ❤️ <%= recipe.favorite_count %>
       <% end %>
     <% else %>

--- a/app/views/shared/_favorite_button.html.erb
+++ b/app/views/shared/_favorite_button.html.erb
@@ -1,0 +1,27 @@
+<div class="favorite-button">
+  <% if user_signed_in? %>
+    <% if current_user.favorited?(recipe) %>
+      <%= link_to recipe_favorite_path(recipe), 
+                  class: "btn btn-outline-danger btn-sm",
+                  data: { turbo_method: :delete } do %>
+        ❤️ <%= recipe.favorite_count %>
+      <% end %>
+    <% else %>
+      <%= link_to recipe_favorite_path(recipe),
+            data: { turbo_method: :post },
+            class: "btn btn-outline-secondary btn-sm",
+            title: "お気に入りに追加",
+            aria: { label: "お気に入りに追加" } do %>
+        🤍 <%= recipe.favorite_count %>
+      <% end %>
+    <% end %>
+
+  <% else %>
+  <%= link_to new_user_session_path,
+           class: "btn btn-outline-secondary btn-sm",
+           title: "ログインしてお気に入り登録",
+           aria: { label: "ログインしてお気に入り登録" } do %>
+      🤍 <%= recipe.favorite_count %>
+    <% end %>
+  <% end %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,18 +1,21 @@
 Rails.application.routes.draw do
-  get 'users/show'
-  get 'users/edit'
-  get 'users/update'
   devise_for :users
-  root 'recipes#index'  # トップページをレシピ一覧に
-  
-  # RESTfulなレシピルーティング
+
+  # トップページ
+  root 'recipes#index'
+
+  # レシピ
   resources :recipes do
-    # 検索機能（/recipes/search）
     collection do
-      get :search
+      get :search   # /recipes/search
+    end
+    resource :favorite, only: [:create, :destroy]  # /recipes/:recipe_id/favorite
+  end
+
+  # ユーザー（プロフィール表示・編集・更新・お気に入り一覧）
+  resources :users, only: [:show, :edit, :update] do
+    member do
+      get :favorites  # /users/:id/favorites
     end
   end
-  
-  # ユーザーのプロフィールページ
-  resources :users, only: [:show, :edit, :update]
 end

--- a/db/migrate/20250827211323_create_favorites.rb
+++ b/db/migrate/20250827211323_create_favorites.rb
@@ -1,14 +1,12 @@
 class CreateFavorites < ActiveRecord::Migration[7.1]
   def change
     create_table :favorites do |t|
-      t.references :user, null: false, foreign_key: true
+      t.references :user,   null: false, foreign_key: true
       t.references :recipe, null: false, foreign_key: true
-
       t.timestamps
 
-          
-    # 同じユーザーが同じレシピを重複してお気に入りできないようにする
-    add_index :favorites, [:user_id, :recipe_id], unique: true
+      # 同じユーザーが同じレシピを重複してお気に入りできないようにする
+      t.index [:user_id, :recipe_id], unique: true
     end
   end
 end

--- a/db/migrate/20250827211323_create_favorites.rb
+++ b/db/migrate/20250827211323_create_favorites.rb
@@ -1,0 +1,14 @@
+class CreateFavorites < ActiveRecord::Migration[7.1]
+  def change
+    create_table :favorites do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :recipe, null: false, foreign_key: true
+
+      t.timestamps
+
+          
+    # 同じユーザーが同じレシピを重複してお気に入りできないようにする
+    add_index :favorites, [:user_id, :recipe_id], unique: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_08_25_145432) do
+ActiveRecord::Schema[7.1].define(version: 2025_08_27_211323) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -40,6 +40,16 @@ ActiveRecord::Schema[7.1].define(version: 2025_08_25_145432) do
     t.bigint "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
+  create_table "favorites", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "recipe_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["recipe_id"], name: "index_favorites_on_recipe_id"
+    t.index ["user_id", "recipe_id"], name: "index_favorites_on_user_id_and_recipe_id", unique: true
+    t.index ["user_id"], name: "index_favorites_on_user_id"
   end
 
   create_table "ingredients", force: :cascade do |t|
@@ -92,6 +102,8 @@ ActiveRecord::Schema[7.1].define(version: 2025_08_25_145432) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "favorites", "recipes"
+  add_foreign_key "favorites", "users"
   add_foreign_key "ingredients", "recipes"
   add_foreign_key "recipes", "users"
   add_foreign_key "steps", "recipes"

--- a/spec/factories/favorites.rb
+++ b/spec/factories/favorites.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :favorite do
+    user { nil }
+    recipe { nil }
+  end
+end

--- a/spec/helpers/favorites_helper_spec.rb
+++ b/spec/helpers/favorites_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the FavoritesHelper. For example:
+#
+# describe FavoritesHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe FavoritesHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/favorite_spec.rb
+++ b/spec/models/favorite_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Favorite, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/favorites_spec.rb
+++ b/spec/requests/favorites_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+RSpec.describe "Favorites", type: :request do
+  describe "GET /create" do
+    it "returns http success" do
+      get "/favorites/create"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe "GET /destroy" do
+    it "returns http success" do
+      get "/favorites/destroy"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+end

--- a/spec/views/favorites/create.html.erb_spec.rb
+++ b/spec/views/favorites/create.html.erb_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "favorites/create.html.erb", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/views/favorites/destroy.html.erb_spec.rb
+++ b/spec/views/favorites/destroy.html.erb_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "favorites/destroy.html.erb", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
## 概要
レシピにお気に入り機能を実装しました。
ユーザーはレシピをお気に入り登録／解除でき、一覧カード上にハートボタンを表示します。

## 実装内容
- Favoriteモデル作成（userとrecipeの中間テーブル、一意制約あり）
- FavoritesController作成（create/destroy）とルーティング更新（/recipes/:id/favorite）
- お気に入りボタンの部分テンプレート作成
- レシピ一覧カードにボタンを組み込み

## 動作確認
- ログイン状態でお気に入り登録／解除ができる
- 一覧・詳細どちらからも正常に動作