### PR TITLE
管理・運用機能2

### DIFF
--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -1,4 +1,3 @@
-# 
 class Admin::BaseController < ApplicationController
   # 全ての管理者コントローラーで管理者認証を必須にする
   before_action :authenticate_admin!

--- a/app/controllers/admin/comments_controller.rb
+++ b/app/controllers/admin/comments_controller.rb
@@ -3,72 +3,95 @@ class Admin::CommentsController < Admin::BaseController
   before_action :set_admin_breadcrumbs
 
   def index
-    # ✅ フィルタ用パラメータ（デフォルト付き）
     @filter_params = {
       search:    params[:search].to_s,
-      status:    (params[:status].presence || ''),          # ''=全て（ビューと一致）
+      status:    (params[:status].presence || ''),            # ''=全て
       sort:      (params[:sort].presence || 'created_desc'),
-      per_page:  (params[:per_page].presence || '20'),      # ビューの選択肢に合わせて20
+      per_page:  (%w[20 50 100].include?(params[:per_page]) ? params[:per_page] : '20'),
       recipe_id: params[:recipe_id].to_s,
       user_id:   params[:user_id].to_s,
-      period:    params[:period].to_s                       # '', today, week, month
+      period:    params[:period].to_s                         # '', today, week, month
     }
 
-    scope = Comment.includes(:user, :recipe)
+    scope = Comment.includes(:user, :recipe, :reports)
 
-    # （任意）検索
+    # 検索
     if @filter_params[:search].present?
-      scope = scope.where('comments.content ILIKE ?', "%#{@filter_params[:search]}%")
+      q = ActiveRecord::Base.sanitize_sql_like(@filter_params[:search])
+      scope = scope.where('comments.content ILIKE ?', "%#{q}%")
     end
 
-    # （任意）ステータス絞り込み：enum(:status) or boolean(:hidden) どちらでも動くように
+    # 絞り込み
+    scope = scope.where(recipe_id: @filter_params[:recipe_id]) if @filter_params[:recipe_id].present?
+    scope = scope.where(user_id:   @filter_params[:user_id])   if @filter_params[:user_id].present?
+
+    case @filter_params[:period]
+    when 'today' then scope = scope.where(created_at: Time.zone.today.all_day)
+    when 'week'  then scope = scope.where(created_at: Time.zone.now.beginning_of_week..Time.zone.now)
+    when 'month' then scope = scope.where(created_at: Time.zone.now.beginning_of_month..Time.zone.now)
+    end
+
     case @filter_params[:status]
     when 'visible'
-      if Comment.column_names.include?('status')
-        scope = scope.where(status: 'visible')
-      elsif Comment.column_names.include?('hidden')
-        scope = scope.where(hidden: false)
-      end
+      scope = scope.where(hidden: false) if Comment.column_names.include?('hidden')
+      scope = scope.where(status: 'visible') if Comment.column_names.include?('status')
     when 'hidden'
-      if Comment.column_names.include?('status')
-        scope = scope.where(status: 'hidden')
-      elsif Comment.column_names.include?('hidden')
-        scope = scope.where(hidden: true)
-      end
+      scope = scope.where(hidden: true) if Comment.column_names.include?('hidden')
+      scope = scope.where(status: 'hidden') if Comment.column_names.include?('status')
     end
 
-    # 並び順（ビューの選択肢に対応）
+    # 並び順
     scope =
-    case @filter_params[:sort]
-    when 'created_asc' then scope.order(created_at: :asc)
-    when 'recipe'      then scope.order(:recipe_id, created_at: :desc)
-    when 'user'        then scope.order(:user_id,   created_at: :desc)
-    else                    scope.order(created_at: :desc) # created_desc
-    end
+      case @filter_params[:sort]
+      when 'created_asc' then scope.order(created_at: :asc)
+      when 'recipe'      then scope.order(:recipe_id, created_at: :desc)
+      when 'user'        then scope.order(:user_id,   created_at: :desc)
+      else                    scope.order(created_at: :desc)
+      end
 
-    # 統計（全体）
+    # 統計（ビューのキーに合わせる）
     @stats = {
-      total:     Comment.count,
-      today:     Comment.where(created_at: Time.zone.today.all_day).count,
-      this_week: Comment.where(created_at: Time.zone.now.beginning_of_week..Time.zone.now).count
+      total:    Comment.count,
+      visible:  (Comment.column_names.include?('hidden') ? Comment.where(hidden: false).count : nil),
+      hidden:   (Comment.column_names.include?('hidden') ? Comment.where(hidden: true).count  : nil),
+      today:    Comment.where(created_at: Time.zone.today.all_day).count,
+      week:     Comment.where(created_at: Time.zone.now.beginning_of_week..Time.zone.now).count,
+      reported: (Comment.reflect_on_association(:reports) ?
+                  (Report.respond_to?(:pending) ?
+                    Comment.joins(:reports).merge(Report.pending).distinct.count :
+                    Comment.joins(:reports).distinct.count)
+                 : nil)
     }
 
     @comments = scope.page(params[:page]).per(@filter_params[:per_page].to_i)
   end
 
   def hide
-    Comment.find(params[:id]).update!(hidden: true)
+    Comment.where(id: params[:id]).update_all(hidden: true,  updated_at: Time.current)
     redirect_back fallback_location: admin_comments_path, notice: '非表示にしました'
   end
 
   def unhide
-    Comment.find(params[:id]).update!(hidden: false)
+    Comment.where(id: params[:id]).update_all(hidden: false, updated_at: Time.current)
     redirect_back fallback_location: admin_comments_path, notice: '表示にしました'
   end
 
   def destroy
-    comment = Comment.find(params[:id])
-    comment.destroy
+    Comment.where(id: params[:id]).destroy_all
     redirect_back fallback_location: admin_comments_path, notice: 'コメントを削除しました'
+  end
+
+  def bulk
+    ids = Array(params[:comment_ids]).map(&:to_i).uniq
+    return redirect_back fallback_location: admin_comments_path, alert: '対象が選択されていません' if ids.empty?
+
+    case params[:bulk_action]
+    when 'hide'   then Comment.where(id: ids).update_all(hidden: true,  updated_at: Time.current);  msg = "#{ids.size}件を非表示にしました"
+    when 'show'   then Comment.where(id: ids).update_all(hidden: false, updated_at: Time.current);  msg = "#{ids.size}件を表示にしました"
+    when 'delete' then Comment.where(id: ids).destroy_all;                                           msg = "#{ids.size}件を削除しました"
+    else return redirect_back fallback_location: admin_comments_path, alert: 'アクションを選択してください'
+    end
+
+    redirect_back fallback_location: admin_comments_path, notice: msg
   end
 end

--- a/app/controllers/admin/comments_controller.rb
+++ b/app/controllers/admin/comments_controller.rb
@@ -1,8 +1,69 @@
-class Admin::CommentsController < ApplicationController
+# app/controllers/admin/comments_controller.rb
+class Admin::CommentsController < Admin::BaseController
+  before_action :set_admin_breadcrumbs
+
   def index
-    @comments = Comment.includes(:user, :recipe)
-                       .order(created_at: :desc)
-                       .page(params[:page]).per(12)
+    # ✅ フィルタ用パラメータ（デフォルト付き）
+    @filter_params = {
+      search:    params[:search].to_s,
+      status:    (params[:status].presence || ''),          # ''=全て（ビューと一致）
+      sort:      (params[:sort].presence || 'created_desc'),
+      per_page:  (params[:per_page].presence || '20'),      # ビューの選択肢に合わせて20
+      recipe_id: params[:recipe_id].to_s,
+      user_id:   params[:user_id].to_s,
+      period:    params[:period].to_s                       # '', today, week, month
+    }
+
+    scope = Comment.includes(:user, :recipe)
+
+    # （任意）検索
+    if @filter_params[:search].present?
+      scope = scope.where('comments.content ILIKE ?', "%#{@filter_params[:search]}%")
+    end
+
+    # （任意）ステータス絞り込み：enum(:status) or boolean(:hidden) どちらでも動くように
+    case @filter_params[:status]
+    when 'visible'
+      if Comment.column_names.include?('status')
+        scope = scope.where(status: 'visible')
+      elsif Comment.column_names.include?('hidden')
+        scope = scope.where(hidden: false)
+      end
+    when 'hidden'
+      if Comment.column_names.include?('status')
+        scope = scope.where(status: 'hidden')
+      elsif Comment.column_names.include?('hidden')
+        scope = scope.where(hidden: true)
+      end
+    end
+
+    # 並び順（ビューの選択肢に対応）
+    scope =
+    case @filter_params[:sort]
+    when 'created_asc' then scope.order(created_at: :asc)
+    when 'recipe'      then scope.order(:recipe_id, created_at: :desc)
+    when 'user'        then scope.order(:user_id,   created_at: :desc)
+    else                    scope.order(created_at: :desc) # created_desc
+    end
+
+    # 統計（全体）
+    @stats = {
+      total:     Comment.count,
+      today:     Comment.where(created_at: Time.zone.today.all_day).count,
+      this_week: Comment.where(created_at: Time.zone.now.beginning_of_week..Time.zone.now).count
+    }
+
+    @comments = scope.page(params[:page]).per(@filter_params[:per_page].to_i)
+  end
+
+  def hide
+    Comment.find(params[:id]).update!(hidden: true)
+    redirect_back fallback_location: admin_comments_path, notice: '非表示にしました'
+  end
+
+  def unhide
+    Comment.find(params[:id]).update!(hidden: false)
+    redirect_back fallback_location: admin_comments_path, notice: '表示にしました'
   end
 
   def destroy

--- a/app/controllers/admin/recipes_controller.rb
+++ b/app/controllers/admin/recipes_controller.rb
@@ -1,48 +1,153 @@
-class Admin::RecipesController < ApplicationController
+class Admin::RecipesController < Admin::BaseController
+  before_action :set_recipe, only: [:show, :destroy, :hide, :unhide] 
+
   def index
-    # フィルタ（必要最低限：検索・並び順・件数）
+    # フィルタ（検索・並び順・件数）
     @filter_params = {
       search:   params[:search].to_s,
       sort:     (params[:sort].presence || 'created_desc').to_s,
       per_page: (params[:per_page].presence || '20').to_s
     }
 
-    scope = Recipe.includes(:user)
+    scope = Recipe
+              .includes(:user, :favorites, :comments, image_attachment: :blob) # N+1回避
+              .references(:user)
 
-    # 検索（公開側のスコープがあれば優先）
+    # 検索
     if @filter_params[:search].present?
-      if scope.respond_to?(:search_by_title_and_description)
+      if Recipe.respond_to?(:search_by_title_and_description)
         scope = scope.search_by_title_and_description(@filter_params[:search])
       else
         q = "%#{@filter_params[:search]}%"
-        begin
-          scope = scope.where('title ILIKE :q OR description ILIKE :q', q: q)
-        rescue
-          scope = scope.where('title LIKE :q OR description LIKE :q', q: q) # MySQL 等
-        end
+        scope =
+          begin
+            scope.where('recipes.title ILIKE :q OR recipes.description ILIKE :q', q: q)
+          rescue
+            scope.where('recipes.title LIKE :q OR recipes.description LIKE :q', q: q)
+          end
       end
     end
 
-    # 並び順（存在チェックつきで安全に）
+    # 並び順（存在チェックつき）
     scope =
       case @filter_params[:sort]
       when 'created_asc'   then scope.order(created_at: :asc)
       when 'cooking_time'
         Recipe.column_names.include?('cooking_time') ? scope.order(:cooking_time) : scope.order(created_at: :desc)
       when 'popular'
-        Recipe.column_names.include?('favorites_count') ? scope.order(favorites_count: :desc) : scope.order(created_at: :desc)
-      else                   scope.order(created_at: :desc) # created_desc
+        # counter_cache があればそれ、無ければ favorites の数で並び替え（少し重い）
+        if Recipe.column_names.include?('favorites_count')
+          scope.order(favorites_count: :desc)
+        else
+          scope.left_joins(:favorites).group('recipes.id').order(Arel.sql('COUNT(favorites.id) DESC'))
+        end
+      else
+        scope.order(created_at: :desc) # created_desc
       end
 
     per = @filter_params[:per_page].to_i
     per = 20 unless [20, 50, 100].include?(per)
     @recipes = scope.page(params[:page]).per(per)
 
-    # ← これが無いとビューで @stats[:...] で落ちる
     @stats = build_stats
   end
 
+  def show
+   # いったん公開側の詳細にリダイレクト（管理用のshowを作るまでの暫定）
+   redirect_to recipe_path(@recipe)
+  end
+
+  def destroy
+    @recipe.destroy
+     redirect_to admin_recipes_path, notice: 'レシピを削除しました'
+  end
+
+  # CSVエクスポート（ルートを追加している場合）
+  def export
+    filters = {
+      search: params[:search].to_s,
+      sort:   (params[:sort].presence || 'created_desc').to_s
+    }
+    scope = Recipe
+              .includes(:user, :favorites, :comments)
+              .references(:user)
+
+    # 検索
+    if filters[:search].present?
+      if Recipe.respond_to?(:search_by_title_and_description)
+        scope = scope.search_by_title_and_description(filters[:search])
+      else
+        q = "%#{filters[:search]}%"
+        scope =
+          begin
+            scope.where('recipes.title ILIKE :q OR recipes.description ILIKE :q', q: q)
+          rescue
+            scope.where('recipes.title LIKE :q OR recipes.description LIKE :q', q: q)
+          end
+      end
+    end
+
+    # 並び順
+    scope =
+      case filters[:sort]
+      when 'created_asc'   then scope.order(created_at: :asc)
+      when 'cooking_time'  then Recipe.column_names.include?('cooking_time') ? scope.order(:cooking_time) : scope.order(created_at: :desc)
+      when 'popular'
+        if Recipe.column_names.include?('favorites_count')
+          scope.order(favorites_count: :desc)
+        else
+          scope.left_joins(:favorites).group('recipes.id').order(Arel.sql('COUNT(favorites.id) DESC'))
+        end
+      else
+        scope.order(created_at: :desc)
+      end
+
+    require 'csv'
+    csv = CSV.generate(headers: true) do |c|
+      c << %w[id title user_email created_at cooking_time favorites comments]
+      scope.find_each do |r|
+        favorites_count = if r.respond_to?(:favorites_count)
+                            r.favorites_count
+                          else
+                            r.association(:favorites).loaded? ? r.favorites.size : r.favorites.count
+                          end
+        comments_count  = if r.respond_to?(:comments_count)
+                            r.comments_count
+                          else
+                            r.association(:comments).loaded? ? r.comments.size : r.comments.count
+                          end
+        c << [r.id, r.title, r.user&.email, r.created_at, (r.respond_to?(:cooking_time) ? r.cooking_time : nil), favorites_count, comments_count]
+      end
+    end
+
+    send_data csv,
+              filename: "recipes_#{Time.zone.now.strftime('%Y%m%d_%H%M%S')}.csv",
+              type: 'text/csv'
+  end
+
+  def hide
+    unless Recipe.column_names.include?('hidden')
+      redirect_back fallback_location: admin_recipes_path, alert: 'hidden カラムがありません' and return
+    end
+    @recipe.update!(hidden: true)
+    redirect_back fallback_location: admin_recipes_path, notice: 'レシピを非公開にしました'
+  end
+
+  def unhide
+    unless Recipe.column_names.include?('hidden')
+      redirect_back fallback_location: admin_recipes_path, alert: 'hidden カラムがありません' and return
+    end
+    @recipe.update!(hidden: false)
+    redirect_back fallback_location: admin_recipes_path, notice: 'レシピを公開にしました'
+  end
+
+  # 必要なら show/edit/update/destroy を追加
+
   private
+
+  def set_recipe
+    @recipe = Recipe.find(params[:id])
+  end
 
   def build_stats
     stats = {
@@ -50,26 +155,9 @@ class Admin::RecipesController < ApplicationController
       today: Recipe.where('created_at >= ?', Time.zone.today.beginning_of_day).count,
       week:  Recipe.where('created_at >= ?', Time.zone.today.beginning_of_week).count
     }
-
-    # 画像付き件数（has_one_attached :image を想定、無ければ 0）
-    if Recipe.reflect_on_association(:image_attachment)
-      stats[:with_image] = Recipe.joins(:image_attachment).distinct.count
-    else
-      stats[:with_image] = 0
-    end
-
-    # コメント付き件数（関連が無ければ 0）
-    if Recipe.reflect_on_association(:comments)
-      stats[:with_comments] = Recipe.joins(:comments).distinct.count
-    else
-      stats[:with_comments] = 0
-    end
-
-    # 平均調理時間（カラムがあれば）
-    if Recipe.column_names.include?('cooking_time')
-      stats[:avg_cooking_time] = Recipe.average(:cooking_time).to_i
-    end
-
+    stats[:with_image] = Recipe.reflect_on_association(:image_attachment) ? Recipe.joins(:image_attachment).distinct.count : 0
+    stats[:with_comments] = Recipe.reflect_on_association(:comments) ? Recipe.joins(:comments).distinct.count : 0
+    stats[:avg_cooking_time] = Recipe.column_names.include?('cooking_time') ? Recipe.average(:cooking_time).to_i : nil
     stats
   end
 end

--- a/app/controllers/admin/recipes_controller.rb
+++ b/app/controllers/admin/recipes_controller.rb
@@ -1,5 +1,75 @@
 class Admin::RecipesController < ApplicationController
   def index
-    @recipes = Recipe.includes(:user).order(created_at: :desc).page(params[:page]).per(20)
+    # フィルタ（必要最低限：検索・並び順・件数）
+    @filter_params = {
+      search:   params[:search].to_s,
+      sort:     (params[:sort].presence || 'created_desc').to_s,
+      per_page: (params[:per_page].presence || '20').to_s
+    }
+
+    scope = Recipe.includes(:user)
+
+    # 検索（公開側のスコープがあれば優先）
+    if @filter_params[:search].present?
+      if scope.respond_to?(:search_by_title_and_description)
+        scope = scope.search_by_title_and_description(@filter_params[:search])
+      else
+        q = "%#{@filter_params[:search]}%"
+        begin
+          scope = scope.where('title ILIKE :q OR description ILIKE :q', q: q)
+        rescue
+          scope = scope.where('title LIKE :q OR description LIKE :q', q: q) # MySQL 等
+        end
+      end
+    end
+
+    # 並び順（存在チェックつきで安全に）
+    scope =
+      case @filter_params[:sort]
+      when 'created_asc'   then scope.order(created_at: :asc)
+      when 'cooking_time'
+        Recipe.column_names.include?('cooking_time') ? scope.order(:cooking_time) : scope.order(created_at: :desc)
+      when 'popular'
+        Recipe.column_names.include?('favorites_count') ? scope.order(favorites_count: :desc) : scope.order(created_at: :desc)
+      else                   scope.order(created_at: :desc) # created_desc
+      end
+
+    per = @filter_params[:per_page].to_i
+    per = 20 unless [20, 50, 100].include?(per)
+    @recipes = scope.page(params[:page]).per(per)
+
+    # ← これが無いとビューで @stats[:...] で落ちる
+    @stats = build_stats
+  end
+
+  private
+
+  def build_stats
+    stats = {
+      total: Recipe.count,
+      today: Recipe.where('created_at >= ?', Time.zone.today.beginning_of_day).count,
+      week:  Recipe.where('created_at >= ?', Time.zone.today.beginning_of_week).count
+    }
+
+    # 画像付き件数（has_one_attached :image を想定、無ければ 0）
+    if Recipe.reflect_on_association(:image_attachment)
+      stats[:with_image] = Recipe.joins(:image_attachment).distinct.count
+    else
+      stats[:with_image] = 0
+    end
+
+    # コメント付き件数（関連が無ければ 0）
+    if Recipe.reflect_on_association(:comments)
+      stats[:with_comments] = Recipe.joins(:comments).distinct.count
+    else
+      stats[:with_comments] = 0
+    end
+
+    # 平均調理時間（カラムがあれば）
+    if Recipe.column_names.include?('cooking_time')
+      stats[:avg_cooking_time] = Recipe.average(:cooking_time).to_i
+    end
+
+    stats
   end
 end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -8,9 +8,40 @@ class Admin::UsersController < Admin::BaseController
     @stats = Admin::UserStats.call
   end
 
+  # ユーザーCSVエクスポート
   def export
     scope = Admin::UsersQuery.new(filter_params).call
-    send_data Admin::UserCsvExporter.call(scope),
+
+    # 集計系を使うなら事前ロードでN+1回避
+    preload_assocs = []
+    preload_assocs << :recipes  if User.reflect_on_association(:recipes)
+    preload_assocs << :comments if User.reflect_on_association(:comments)
+    scope = scope.includes(preload_assocs) if preload_assocs.any?
+
+    require 'csv'
+    csv = CSV.generate(headers: true) do |c|
+      headers = %w[id name email admin created_at]
+      headers << 'recipes_count'  if User.reflect_on_association(:recipes)
+      headers << 'comments_count' if User.reflect_on_association(:comments)
+      headers << 'last_sign_in_at' if User.column_names.include?('last_sign_in_at')
+      c << headers
+
+      scope.find_each do |u|
+        row = [
+          u.id,
+          (u.respond_to?(:display_name) ? u.display_name : u.name),
+          u.email,
+          u.admin?,
+          u.created_at
+        ]
+        row << (u.respond_to?(:recipes)  ? u.recipes.size  : nil) if headers.include?('recipes_count')
+        row << (u.respond_to?(:comments) ? u.comments.size : nil) if headers.include?('comments_count')
+        row << u[:last_sign_in_at] if headers.include?('last_sign_in_at')
+        c << row
+      end
+    end
+
+    send_data csv,
               filename: "users_#{Time.zone.now.strftime('%Y%m%d_%H%M%S')}.csv",
               type: 'text/csv'
   end
@@ -33,13 +64,17 @@ class Admin::UsersController < Admin::BaseController
   end
 
   def suspend
-    ensure_suspended_column!
+    unless User.column_names.include?('suspended')
+      redirect_back fallback_location: admin_users_path, alert: 'suspended カラムがありません' and return
+    end
     @user.update!(suspended: true)
     redirect_back fallback_location: admin_users_path, notice: '停止しました'
   end
 
   def unsuspend
-    ensure_suspended_column!
+    unless User.column_names.include?('suspended')
+      redirect_back fallback_location: admin_users_path, alert: 'suspended カラムがありません' and return
+    end
     @user.update!(suspended: false)
     redirect_back fallback_location: admin_users_path, notice: '停止を解除しました'
   end
@@ -50,7 +85,10 @@ class Admin::UsersController < Admin::BaseController
   end
 
   private
-  def set_user; @user = User.find(params[:id]); end
+
+  def set_user
+    @user = User.find(params[:id])
+  end
 
   def user_params
     params.require(:user).permit(:name, :email, :admin)
@@ -66,11 +104,4 @@ class Admin::UsersController < Admin::BaseController
     n = filter_params['per_page'].to_i
     [20, 50, 100].include?(n) ? n : 20
   end
-
-  def ensure_suspended_column!
-    unless User.column_names.include?('suspended')
-      redirect_back fallback_location: admin_users_path, alert: 'suspended カラムがありません' and return
-    end
-  end
 end
-

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -22,7 +22,6 @@ class CommentsController < ApplicationController
     end
   end
 
-  
   private
   def set_recipe
     @recipe = Recipe.find(params[:recipe_id])

--- a/app/controllers/recipes_controller.rb
+++ b/app/controllers/recipes_controller.rb
@@ -45,6 +45,7 @@ class RecipesController < ApplicationController
     @user   = @recipe.user   # ←@user が nil（→ avatar で落ちる）を防ぐ
   end
 
+
   def new
     @recipe = current_user.recipes.build
     @recipe.ingredients.build(order_number: 1)  if @recipe.ingredients.empty?

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -2,7 +2,7 @@ class Comment < ApplicationRecord
   include Reportable
 
   belongs_to :user
-  belongs_to :recipe
+  belongs_to :recipe, counter_cache: true
 
   validates :content, presence: true, length: { maximum: 500 }
   

--- a/app/models/favorite.rb
+++ b/app/models/favorite.rb
@@ -1,6 +1,6 @@
 class Favorite < ApplicationRecord
   belongs_to :user
-  belongs_to :recipe
+  belongs_to :recipe, counter_cache: true
 
   # 同じユーザー・レシピの組み合わせは一意
   validates :user_id, uniqueness: { scope: :recipe_id }

--- a/app/models/recipe.rb
+++ b/app/models/recipe.rb
@@ -42,6 +42,8 @@ class Recipe < ApplicationRecord
   # スコープ
   scope :recent, -> { order(created_at: :desc) }
   scope :by_cooking_time, ->(time) { where('cooking_time <= ?', time.to_i) }
+  scope :visible, -> { where(hidden: false) }
+  scope :hidden,  -> { where(hidden: true)  }
 
   # 検索用スコープ
   scope :search_by_title_and_description, ->(keyword) {

--- a/app/views/admin/comments/index.html.erb
+++ b/app/views/admin/comments/index.html.erb
@@ -153,8 +153,8 @@
     <% if @comments.any? %>
       <!-- 一括操作フォーム -->
       <div id="bulkActionForm" class="bg-light p-3 border-bottom" style="display: none;">
-        <%= form_with url: admin_bulk_comments_path, method: :patch, 
-            class: "d-flex align-items-center gap-3", id: "bulk-form" do |form| %>
+       <%= form_with url: bulk_admin_comments_path, method: :patch,
+            class: "d-flex align-items-center gap-3", id: "bulk-form", local: true do |form| %>
           <%= form.select :bulk_action, 
               options_for_select([
                 ['アクションを選択', ''],
@@ -321,7 +321,9 @@
             <%= page_entries_info @comments, entry_name: 'コメント' %>
           </div>
           <div>
-            <%= paginate @comments, theme: 'twitter-bootstrap-4' %>
+            
+
+            <%= paginate @comments, theme: 'bootstrap4' %>
           </div>
         </div>
       </div>

--- a/app/views/admin/comments/index.html.erb
+++ b/app/views/admin/comments/index.html.erb
@@ -49,14 +49,11 @@
       <!-- 表示状態フィルター -->
       <div class="col-md-2">
         <%= form.label :status, "表示状態", class: "form-label" %>
-        <%= form.select :status, 
-            options_for_select([
-              ['全て', ''],
-              ['表示中', 'visible'],
-              ['非表示', 'hidden']
-            ], @filter_params[:status]), 
-            {}, 
-            { class: "form-select" } %>
+        <%= form.select :status,
+              options_for_select([['全て',''], ['表示中','visible'], ['非表示','hidden']],
+                                 @filter_params&.fetch(:status, '')),
+              {},
+              { class: "form-select" } %>
       </div>
 
       <!-- レシピフィルター -->

--- a/app/views/admin/recipes/index.html.erb
+++ b/app/views/admin/recipes/index.html.erb
@@ -12,15 +12,16 @@
             <small class="text-muted">総レシピ数</small>
           </div>
           <div class="col-md-2">
-            <h4 class="text-success mb-0"><%= @stats[:published] %></h4>
+            <h4 class="text-success mb-0"><%= (@stats[:published] || (@stats[:total].to_i - @stats[:hidden].to_i)) %></h4>
             <small class="text-muted">公開中</small>
           </div>
           <div class="col-md-2">
-            <h4 class="text-warning mb-0"><%= @stats[:hidden] %></h4>
+            <h4 class="text-warning mb-0"><%= (@stats[:hidden] || 0) %></h4>
             <small class="text-muted">非公開</small>
           </div>
           <div class="col-md-2">
             <h4 class="text-info mb-0"><%= @stats[:today] %></h4>
+            
             <small class="text-muted">今日投稿</small>
           </div>
           <div class="col-md-2">
@@ -28,7 +29,7 @@
             <small class="text-muted">今週投稿</small>
           </div>
           <div class="col-md-2">
-            <h4 class="text-danger mb-0"><%= @stats[:reported] %></h4>
+            <h4 class="text-danger mb-0"><%= (@stats[:reported] || 0) %></h4>
             <small class="text-muted">報告あり</small>
           </div>
         </div>
@@ -95,15 +96,15 @@
       <!-- ソート順 -->
       <div class="col-md-2">
         <%= form.label :sort, "並び順", class: "form-label" %>
-        <%= form.select :sort, 
-            options_for_select([
-              ['新しい順', 'created_desc'],
-              ['古い順', 'created_asc'],
-              ['人気順', 'favorites_desc'],
-              ['コメント順', 'comments_desc']
-            ], @filter_params[:sort]), 
-            {}, 
-            { class: "form-select" } %>
+        <%= form.select :sort,
+        options_for_select([
+          ['新しい順', 'created_desc'],
+          ['古い順',   'created_asc'],
+          ['調理時間', 'cooking_time'],
+          ['人気順',   'popular']
+        ], @filter_params[:sort]),
+        {},
+        { class: "form-select" } %>
       </div>
 
       <!-- 検索・リセットボタン -->
@@ -206,9 +207,8 @@
                 
                 <!-- 投稿者情報 -->
                 <div class="d-flex align-items-center mb-2">
-                  <% if recipe.user.avatar.attached? %>
-                    <%= image_tag recipe.user.avatar, 
-                        class: "rounded-circle me-2", size: "24x24" %>
+                  <% if recipe.user&.avatar&.attached? %>
+                    <%= image_tag recipe.user.avatar, class: "rounded-circle me-2", size: "24x24" %>
                   <% else %>
                     <div class="rounded-circle bg-secondary d-flex align-items-center justify-content-center me-2" 
                          style="width: 24px; height: 24px;">
@@ -225,8 +225,8 @@
                 <div class="d-flex justify-content-between text-muted small mb-2">
                   <span><i class="fas fa-clock"></i> <%= recipe.cooking_time %>分</span>
                   <span><i class="fas fa-users"></i> <%= recipe.servings %>人分</span>
-                  <span><i class="fas fa-heart"></i> <%= recipe.favorites_count %></span>
-                  <span><i class="fas fa-comment"></i> <%= recipe.comments_count %></span>
+                  <span><i class="fas fa-heart"></i> <%= recipe.favorites.size %></span>
+                  <span><i class="fas fa-comment"></i> <%= recipe.comments.size %></span>
                 </div>
                 
                 <!-- カテゴリタグ -->
@@ -247,40 +247,28 @@
               <!-- アクションボタン -->
               <div class="card-footer bg-transparent">
                 <div class="btn-group w-100" role="group">
-                  <%= link_to admin_recipe_path(recipe), 
-                      class: "btn btn-sm btn-outline-primary" do %>
+                  <%= link_to admin_recipe_path(recipe), class: "btn btn-sm btn-outline-primary" do %>
                     <i class="fas fa-eye"></i>
                   <% end %>
-                  
                   <% if recipe.hidden? %>
-                    <%= link_to show_admin_recipe_path(recipe), 
+                    <%= link_to unhide_admin_recipe_path(recipe),
                         method: :patch,
-                        class: "btn btn-sm btn-outline-success",
-                        data: { 
-                          turbo_method: :patch,
-                          confirm: "このレシピを公開しますか？"
-                        } do %>
+                        data: { turbo_method: :patch, confirm: "このレシピを公開しますか？" },
+                        class: "btn btn-sm btn-outline-success" do %>
                       <i class="fas fa-eye"></i>
                     <% end %>
                   <% else %>
-                    <%= link_to hide_admin_recipe_path(recipe), 
+                    <%= link_to hide_admin_recipe_path(recipe),
                         method: :patch,
-                        class: "btn btn-sm btn-outline-warning",
-                        data: { 
-                          turbo_method: :patch,
-                          confirm: "このレシピを非公開にしますか？"
-                        } do %>
+                        data: { turbo_method: :patch, confirm: "このレシピを非公開にしますか？" },
+                        class: "btn btn-sm btn-outline-warning" do %>
                       <i class="fas fa-eye-slash"></i>
                     <% end %>
                   <% end %>
-                  
-                  <%= link_to admin_recipe_path(recipe), 
+                  <%= link_to admin_recipe_path(recipe),
                       method: :delete,
-                      class: "btn btn-sm btn-outline-danger",
-                      data: { 
-                        turbo_method: :delete,
-                        confirm: "このレシピを削除しますか？この操作は取り消せません。"
-                      } do %>
+                      data: { turbo_method: :delete, confirm: "このレシピを削除しますか？この操作は取り消せません。" },
+                      class: "btn btn-sm btn-outline-danger" do %>
                     <i class="fas fa-trash"></i>
                   <% end %>
                 </div>
@@ -290,15 +278,15 @@
         <% end %>
       </div>
 
-      <!-- ページネーション -->
-      <div class="d-flex justify-content-between align-items-center mt-4">
-        <div class="text-muted">
-          <%= page_entries_info @recipes, entry_name: 'レシピ' %>
-        </div>
-        <div>
-          <%= paginate @recipes, theme: 'twitter-bootstrap-4' %>
-        </div>
-      </div>
+<!-- ページネーション -->
+<div class="d-flex justify-content-between align-items-center mt-4">
+  <div class="text-muted">
+    <%= page_entries_info @recipes, entry_name: 'レシピ' %>
+  </div>
+  <div>
+    <%= paginate @recipes, theme: 'bootstrap4', params: (@filter_params || {}) %>
+  </div>
+</div>
     <% else %>
       <!-- 空状態 -->
       <div class="text-center py-5">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -52,7 +52,8 @@ Rails.application.routes.draw do
       end
     end
   
-    resources :recipes, only: [:index, :show, :edit, :update, :destroy]
+    get 'recipes/export', to: 'recipes#export', as: :recipes_export
+    resources :recipes, only: [:index, :show, :edit, :update, :destroy]    
     
     resources :comments, only: [:index, :destroy]
   end 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -59,8 +59,17 @@ Rails.application.routes.draw do
         patch :hide
         patch :unhide
       end
-    end         
-    
-    resources :comments, only: [:index, :destroy]
+    end   
+
+    # comments
+    resources :comments, only: [:index, :show, :destroy] do
+        collection { patch :bulk }     # => bulk_admin_comments_path
+        member do
+          patch :hide                  # => hide_admin_comment_path(:id)
+          patch :unhide                # unhide_admin_comment_path(:id) ←コメント修正
+        end
+      end
+    end
+
   end 
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,4 @@
+# config/routes.rb
 Rails.application.routes.draw do
   devise_for :users
 
@@ -7,69 +8,61 @@ Rails.application.routes.draw do
   # レシピ
   resources :recipes do
     collection do
-      get :search   # /recipes/search
-      get :feed  # タイムライン追加
+      get :search
+      get :feed
     end
-    resource :favorite, only: [:create, :destroy]  # /recipes/:recipe_id/favorite
-    resources :comments, only: [:create, :destroy]  # 追加
-    resources :ratings, only: [:create]  # 追加
+    resource  :favorite, only: [:create, :destroy]
+    resources :comments, only: [:create, :destroy]
+    resources :ratings,  only: [:create]
   end
 
-  # ユーザー（プロフィール表示・編集・更新・お気に入り一覧）
+  # ユーザー
   resources :users, only: [:show, :edit, :update] do
-    member do
-      get :favorites  # /users/:id/favorites
-    end
-    resource :follow, only: [:create, :destroy] 
+    member { get :favorites }
+    resource :follow, only: [:create, :destroy]
   end
 
-  # ===== レポート機能（新規追加） =====
+  # レポート（公開側）
   resources :reports, only: [:create]
   get 'reports/recipes/:recipe_id/new',   to: 'reports#new', as: :new_recipe_report
   get 'reports/comments/:comment_id/new', to: 'reports#new', as: :new_comment_report
   get 'reports/users/:user_id/new',       to: 'reports#new', as: :new_user_report
 
-  # ===== 管理者機能（新規追加） =====
+  # 管理者
   namespace :admin do
-    root 'dashboard#index'  # admin/ でダッシュボードにアクセス
-    
+    root 'dashboard#index'
+
     resources :reports, only: [:index, :show] do
       member do
-        patch :resolve      # レポート解決
-        patch :dismiss      # レポート却下
-        patch :investigate  # 調査開始
+        patch :resolve
+        patch :dismiss
+        patch :investigate
       end
     end
-    
-    # Users
+
     get 'users/export', to: 'users#export', as: :users_export
     resources :users, only: [:index, :show, :edit, :update] do
       member do
-        patch :toggle_admin  # 管理者権限の付与・剥奪
+        patch :toggle_admin
         patch :suspend
         patch :unsuspend
         patch :promote
       end
     end
-  
-    # Recipes
+
     get 'recipes/export', to: 'recipes#export', as: :recipes_export
     resources :recipes, only: [:index, :show, :edit, :update, :destroy] do
       member do
         patch :hide
         patch :unhide
       end
-    end   
-
-    # comments
+    end
     resources :comments, only: [:index, :show, :destroy] do
-        collection { patch :bulk }     # => bulk_admin_comments_path
-        member do
-          patch :hide                  # => hide_admin_comment_path(:id)
-          patch :unhide                # unhide_admin_comment_path(:id) ←コメント修正
-        end
+      collection { patch :bulk }   # => bulk_admin_comments_path
+      member do
+        patch :hide               # => hide_admin_comment_path(:id)
+        patch :unhide             # => unhide_admin_comment_path(:id)
       end
     end
-
-  end 
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -41,7 +41,7 @@ Rails.application.routes.draw do
       end
     end
     
-    # CSV エクスポート（ヘルパーを admin_users_export_path にする）
+    # Users
     get 'users/export', to: 'users#export', as: :users_export
     resources :users, only: [:index, :show, :edit, :update] do
       member do
@@ -52,8 +52,14 @@ Rails.application.routes.draw do
       end
     end
   
+    # Recipes
     get 'recipes/export', to: 'recipes#export', as: :recipes_export
-    resources :recipes, only: [:index, :show, :edit, :update, :destroy]    
+    resources :recipes, only: [:index, :show, :edit, :update, :destroy] do
+      member do
+        patch :hide
+        patch :unhide
+      end
+    end         
     
     resources :comments, only: [:index, :destroy]
   end 

--- a/db/migrate/20250922193248_add_hidden_to_recipes.rb
+++ b/db/migrate/20250922193248_add_hidden_to_recipes.rb
@@ -1,0 +1,5 @@
+class AddHiddenToRecipes < ActiveRecord::Migration[7.1]
+  def change
+    add_column :recipes, :hidden, :boolean
+  end
+end

--- a/db/migrate/20250922193248_add_hidden_to_recipes.rb
+++ b/db/migrate/20250922193248_add_hidden_to_recipes.rb
@@ -1,5 +1,6 @@
 class AddHiddenToRecipes < ActiveRecord::Migration[7.1]
   def change
-    add_column :recipes, :hidden, :boolean
+    add_column :recipes, :hidden, :boolean, null: false, default: false
+    add_index  :recipes, :hidden
   end
 end

--- a/db/migrate/20250922195528_add_counter_caches_to_recipes.rb
+++ b/db/migrate/20250922195528_add_counter_caches_to_recipes.rb
@@ -1,0 +1,8 @@
+class AddCounterCachesToRecipes < ActiveRecord::Migration[7.1]
+  def change
+    add_column :recipes, :favorites_count, :integer, null: false, default: 0
+    add_column :recipes, :comments_count,  :integer, null: false, default: 0
+    add_index  :recipes, :favorites_count
+    add_index  :recipes, :comments_count
+  end
+end

--- a/db/migrate/20250924192330_add_hidden_to_comments.rb
+++ b/db/migrate/20250924192330_add_hidden_to_comments.rb
@@ -1,0 +1,6 @@
+class AddHiddenToComments < ActiveRecord::Migration[7.1]
+  def change
+    add_column :comments, :hidden, :boolean, null: false, default: false
+    add_index  :comments, :hidden
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_09_21_195929) do
+ActiveRecord::Schema[7.1].define(version: 2025_09_22_193248) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -123,7 +123,9 @@ ActiveRecord::Schema[7.1].define(version: 2025_09_21_195929) do
     t.bigint "user_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "hidden", default: false, null: false
     t.index ["created_at"], name: "index_recipes_on_created_at"
+    t.index ["hidden"], name: "index_recipes_on_hidden"
     t.index ["title"], name: "index_recipes_on_title"
     t.index ["user_id"], name: "index_recipes_on_user_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_09_22_195528) do
+ActiveRecord::Schema[7.1].define(version: 2025_09_24_192330) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -56,7 +56,9 @@ ActiveRecord::Schema[7.1].define(version: 2025_09_22_195528) do
     t.bigint "recipe_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "hidden", default: false, null: false
     t.index ["created_at"], name: "index_comments_on_created_at"
+    t.index ["hidden"], name: "index_comments_on_hidden"
     t.index ["recipe_id"], name: "index_comments_on_recipe_id"
     t.index ["user_id"], name: "index_comments_on_user_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_09_22_193248) do
+ActiveRecord::Schema[7.1].define(version: 2025_09_22_195528) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -124,7 +124,11 @@ ActiveRecord::Schema[7.1].define(version: 2025_09_22_193248) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "hidden", default: false, null: false
+    t.integer "favorites_count", default: 0, null: false
+    t.integer "comments_count", default: 0, null: false
+    t.index ["comments_count"], name: "index_recipes_on_comments_count"
     t.index ["created_at"], name: "index_recipes_on_created_at"
+    t.index ["favorites_count"], name: "index_recipes_on_favorites_count"
     t.index ["hidden"], name: "index_recipes_on_hidden"
     t.index ["title"], name: "index_recipes_on_title"
     t.index ["user_id"], name: "index_recipes_on_user_id"


### PR DESCRIPTION
管理画面のユーザー一覧／レシピ一覧を安定化＆機能追加 + コメント管理修正
概要
管理画面のユーザー/レシピ一覧の安定化・機能追加（CSV出力、公開/非公開トグル、ページネーション統一）に加え、コメント管理画面へ遷移できない問題と表示/非表示運用を修正。

Routing: admin_users_export / admin_recipes_export 追加、recipes#hide/unhide、comments#bulk/hide/unhide。
Users: #export 実装、index に @filter_params/@stats、、ページネーション安定化。
Recipes: index 検索・ソート（created_asc/desc 等）、#export CSV、hide/unhide、destroy。
Comments: index フィルタ・統計、bulk/hide/unhide/destroy 実装、フォームURLを bulk_admin_comments_path に修正。
Kaminari: テーマを bootstrap4 に統一（Missing partial 解消、フィルタ保持）。

動作確認: /admin/users・/admin/recipes・/admin/comments 一覧表示OK、検索/ソート/ページネーションOK、CSV DL、公開/非公開トグル、一括操作OK。
影響範囲: 管理画面のみ。counter_cache 無しでも動作。