### PR TITLE
管理・運用機能3

### DIFF
--- a/app/assets/stylesheets/admin.css
+++ b/app/assets/stylesheets/admin.css
@@ -82,4 +82,28 @@
       border: none;
       border-radius: 8px;
     }
+
+    /* アクション群を折り返し＆余白確保 */
+    .admin-card-actions {
+      display: flex;
+      flex-wrap: wrap;
+      gap: .5rem;            /* ボタン間のすき間 */
+    }
     
+    /* ボタンを均等に広げて押しやすく */
+    .admin-card-actions .btn {
+      flex: 1 1 0;           /* 幅を均等配分 */
+      white-space: nowrap;   /* テキストの折返し防止 */
+    }
+    
+    /* どうしても小さくしたい時の控えめなサイズ調整（任意） */
+    .admin-card-actions .btn.btn-sm {
+      padding: .3rem .5rem;
+      font-size: .875rem;
+    }
+    
+    /* カード内余白が詰まってる場合の保険 */
+    .card-footer.bg-transparent {
+      padding-top: .75rem;
+      padding-bottom: .75rem;
+    }

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -46,7 +46,47 @@ class Admin::UsersController < Admin::BaseController
               type: 'text/csv'
   end
 
-  def show; end
+  def show
+    # 統計・一覧（既存）
+    @user_stats = {
+      recipes_count:    @user.recipes.count,
+      comments_count:   @user.comments.count,
+      favorites_count:  @user.favorites.count,
+      ratings_count:    @user.ratings.count,
+      followers_count:  @user.followers.count,
+      followings_count: @user.followings.count
+    }
+  
+    @recipes  = @user.recipes.order(created_at: :desc)
+                     .page(params[:recipes_page]).per(20)
+    @comments = @user.comments.order(created_at: :desc)
+                     .page(params[:comments_page]).per(20)
+  
+    # ★ ここから追加：関連レポート
+    if ActiveRecord::Base.connection.data_source_exists?(:reports)
+      reports_scope = Report.none
+      reports_scope = reports_scope.or(Report.where(reportable: @user))
+      reports_scope = reports_scope.or(
+        Report.where(reportable_type: 'Recipe',
+                     reportable_id: @user.recipes.select(:id))
+      )
+      reports_scope = reports_scope.or(
+        Report.where(reportable_type: 'Comment',
+                     reportable_id: @user.comments.select(:id))
+      )
+  
+      @related_reports  = reports_scope
+                            .includes(:user, :reportable)   # reporter と対象を先読み
+                            .order(created_at: :desc)
+  
+      @submitted_reports = Report.where(user_id: @user.id)
+                                 .includes(:reportable)
+                                 .order(created_at: :desc)
+    else
+      @related_reports   = []
+      @submitted_reports = []
+  end
+
   def edit; end
 
   def update
@@ -96,12 +136,14 @@ class Admin::UsersController < Admin::BaseController
 
   def filter_params
     params.permit(:status, :role, :period, :activity, :sort, :search, :per_page)
-          .to_h.transform_values { |v| v.to_s }
-          .reverse_merge('sort' => 'created_desc', 'per_page' => '20')
+          .to_h
+          .symbolize_keys
+          .reverse_merge(sort: 'created_desc', per_page: '20')
   end
-
+  
   def per_page
-    n = filter_params['per_page'].to_i
+    n = filter_params[:per_page].to_i
     [20, 50, 100].include?(n) ? n : 20
   end
+end
 end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -12,7 +12,6 @@ class Admin::UsersController < Admin::BaseController
   def export
     scope = Admin::UsersQuery.new(filter_params).call
 
-    # 集計系を使うなら事前ロードでN+1回避
     preload_assocs = []
     preload_assocs << :recipes  if User.reflect_on_association(:recipes)
     preload_assocs << :comments if User.reflect_on_association(:comments)
@@ -21,8 +20,8 @@ class Admin::UsersController < Admin::BaseController
     require 'csv'
     csv = CSV.generate(headers: true) do |c|
       headers = %w[id name email admin created_at]
-      headers << 'recipes_count'  if User.reflect_on_association(:recipes)
-      headers << 'comments_count' if User.reflect_on_association(:comments)
+      headers << 'recipes_count'   if User.reflect_on_association(:recipes)
+      headers << 'comments_count'  if User.reflect_on_association(:comments)
       headers << 'last_sign_in_at' if User.column_names.include?('last_sign_in_at')
       c << headers
 
@@ -47,7 +46,6 @@ class Admin::UsersController < Admin::BaseController
   end
 
   def show
-    # 統計・一覧（既存）
     @user_stats = {
       recipes_count:    @user.recipes.count,
       comments_count:   @user.comments.count,
@@ -56,13 +54,13 @@ class Admin::UsersController < Admin::BaseController
       followers_count:  @user.followers.count,
       followings_count: @user.followings.count
     }
-  
+
     @recipes  = @user.recipes.order(created_at: :desc)
                      .page(params[:recipes_page]).per(20)
     @comments = @user.comments.order(created_at: :desc)
                      .page(params[:comments_page]).per(20)
-  
-    # ★ ここから追加：関連レポート
+
+    # 関連レポート
     if ActiveRecord::Base.connection.data_source_exists?(:reports)
       reports_scope = Report.none
       reports_scope = reports_scope.or(Report.where(reportable: @user))
@@ -74,17 +72,18 @@ class Admin::UsersController < Admin::BaseController
         Report.where(reportable_type: 'Comment',
                      reportable_id: @user.comments.select(:id))
       )
-  
-      @related_reports  = reports_scope
-                            .includes(:user, :reportable)   # reporter と対象を先読み
-                            .order(created_at: :desc)
-  
+
+      @related_reports = reports_scope
+                           .includes(:user, :reportable)
+                           .order(created_at: :desc)
+
       @submitted_reports = Report.where(user_id: @user.id)
-                                 .includes(:reportable)
-                                 .order(created_at: :desc)
+                                .includes(:reportable)
+                                .order(created_at: :desc)
     else
       @related_reports   = []
       @submitted_reports = []
+    end
   end
 
   def edit; end
@@ -140,10 +139,9 @@ class Admin::UsersController < Admin::BaseController
           .symbolize_keys
           .reverse_merge(sort: 'created_desc', per_page: '20')
   end
-  
+
   def per_page
     n = filter_params[:per_page].to_i
     [20, 50, 100].include?(n) ? n : 20
   end
-end
 end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -103,18 +103,19 @@ class Admin::UsersController < Admin::BaseController
   end
 
   def suspend
-    unless User.column_names.include?('suspended')
-      redirect_back fallback_location: admin_users_path, alert: 'suspended カラムがありません' and return
-    end
-    @user.update!(suspended: true)
+    dur = params[:suspend_duration].to_i # '1','3','7','30','0'
+    until_time = dur.zero? ? nil : Time.current + dur.days
+  
+    @user.update!(
+      suspended: dur.zero? ? true : false,   # 無期限→true / 期間→falseでもuntilで止まる
+      suspended_until: until_time,
+      suspend_reason: params[:suspend_reason]
+    )
     redirect_back fallback_location: admin_users_path, notice: '停止しました'
   end
-
+  
   def unsuspend
-    unless User.column_names.include?('suspended')
-      redirect_back fallback_location: admin_users_path, alert: 'suspended カラムがありません' and return
-    end
-    @user.update!(suspended: false)
+    @user.update!(suspended: false, suspended_until: nil, suspend_reason: nil)
     redirect_back fallback_location: admin_users_path, notice: '停止を解除しました'
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,12 +1,14 @@
 class ApplicationController < ActionController::Base
-  before_action :reject_suspended_user
-
     # CSRF保護
     protect_from_forgery with: :exception
   
     # Devise用の設定
     before_action :authenticate_user!
     before_action :configure_permitted_parameters, if: :devise_controller?
+
+    # Deviseの画面（ログイン/新規登録/パスワード系）は認証スキップ
+    skip_before_action :authenticate_user!, if: :devise_controller?
+    before_action :reject_suspended_user
   
     protected
     # Deviseのパラメータ設定（既存）

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,6 @@
 class ApplicationController < ActionController::Base
+  before_action :reject_suspended_user
+
     # CSRF保護
     protect_from_forgery with: :exception
   
@@ -53,6 +55,15 @@ class ApplicationController < ActionController::Base
      respond_to do |format|
        format.html { block.call if block_given? }
        format.js   { block.call if block_given? }
+     end
+   end
+
+   # アカウント停止か判断
+   def reject_suspended_user
+     return unless user_signed_in?
+     if current_user.suspended?
+       sign_out current_user
+       redirect_to new_user_session_path, alert: 'アカウントは停止中です。'
      end
    end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -41,4 +41,34 @@ class UsersController < ApplicationController
   def correct_user
     redirect_to root_path unless current_user == @user
   end
+
+  def active_for_authentication?
+    super && !suspended?
+  end
+  
+  def suspended?
+    # 無期限（suspended:true） or 期限付き（suspended_until）どちらでもロック扱い
+    (self[:suspended] == true) || (suspended_until.present? && Time.current < suspended_until)
+  end
+  
+  def inactive_message
+    suspended? ? :locked : super
+  end
+
+  def suspend
+    dur = params[:suspend_duration].to_i # '1','3','7','30','0'
+    until_time = dur.zero? ? nil : Time.current + dur.days
+  
+    @user.update!(
+      suspended: dur.zero? ? true : false,
+      suspended_until: until_time,
+      suspend_reason: params[:suspend_reason]
+    )
+    redirect_back fallback_location: admin_users_path, notice: '停止しました'
+  end
+  
+  def unsuspend
+    @user.update!(suspended: false, suspended_until: nil, suspend_reason: nil)
+    redirect_back fallback_location: admin_users_path, notice: '停止を解除しました'
+  end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -42,18 +42,7 @@ class UsersController < ApplicationController
     redirect_to root_path unless current_user == @user
   end
 
-  def active_for_authentication?
-    super && !suspended?
-  end
-  
-  def suspended?
-    # 無期限（suspended:true） or 期限付き（suspended_until）どちらでもロック扱い
-    (self[:suspended] == true) || (suspended_until.present? && Time.current < suspended_until)
-  end
-  
-  def inactive_message
-    suspended? ? :locked : super
-  end
+ 
 
   def suspend
     dur = params[:suspend_duration].to_i # '1','3','7','30','0'

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -104,4 +104,16 @@ class User < ApplicationRecord
     admin_handled_reports.count
   end
 
+  # アカウント停止の処理
+  def active_for_authentication?
+    super && !suspended?
+  end
+  def suspended?
+    # 無期限（suspended:true） or 期限付き（suspended_until）どちらでもロック扱い
+    (self[:suspended] == true) || (suspended_until.present? && Time.current < suspended_until)
+  end
+  def inactive_message
+    suspended? ? :locked : super
+  end
+
 end

--- a/app/views/admin/recipes/index.html.erb
+++ b/app/views/admin/recipes/index.html.erb
@@ -243,36 +243,39 @@
                   <%= recipe.created_at.strftime("%Y/%m/%d %H:%M") %>
                 </small>
               </div>
-              
-              <!-- アクションボタン -->
-              <div class="card-footer bg-transparent">
-                <div class="btn-group w-100" role="group">
-                  <%= link_to admin_recipe_path(recipe), class: "btn btn-sm btn-outline-primary" do %>
-                    <i class="fas fa-eye"></i>
-                  <% end %>
-                  <% if recipe.hidden? %>
-                    <%= link_to unhide_admin_recipe_path(recipe),
-                        method: :patch,
-                        data: { turbo_method: :patch, confirm: "このレシピを公開しますか？" },
-                        class: "btn btn-sm btn-outline-success" do %>
-                      <i class="fas fa-eye"></i>
-                    <% end %>
-                  <% else %>
-                    <%= link_to hide_admin_recipe_path(recipe),
-                        method: :patch,
-                        data: { turbo_method: :patch, confirm: "このレシピを非公開にしますか？" },
-                        class: "btn btn-sm btn-outline-warning" do %>
-                      <i class="fas fa-eye-slash"></i>
-                    <% end %>
-                  <% end %>
-                  <%= link_to admin_recipe_path(recipe),
-                      method: :delete,
-                      data: { turbo_method: :delete, confirm: "このレシピを削除しますか？この操作は取り消せません。" },
-                      class: "btn btn-sm btn-outline-danger" do %>
-                    <i class="fas fa-trash"></i>
-                  <% end %>
-                </div>
-              </div>
+          
+             <!-- アクションボタン修正部分 -->
+             <div class="card-footer bg-transparent">
+               <div class="btn-group w-100 admin-card-actions" role="group">
+                 <%= link_to admin_recipe_path(recipe), class: "btn btn-outline-primary" do %>
+                   <i class="fas fa-eye"></i><span class="d-none d-sm-inline ms-1">詳細</span>
+                 <% end %>
+             
+                 <% if recipe.hidden? %>
+                   <%= link_to unhide_admin_recipe_path(recipe),
+                       method: :patch,
+                       data: { turbo_method: :patch, confirm: "このレシピを公開しますか？" },
+                       class: "btn btn-outline-success" do %>
+                     <i class="fas fa-eye"></i><span class="d-none d-sm-inline ms-1">公開</span>
+                   <% end %>
+                 <% else %>
+                   <%= link_to hide_admin_recipe_path(recipe),
+                       method: :patch,
+                       data: { turbo_method: :patch, confirm: "このレシピを非公開にしますか？" },
+                       class: "btn btn-outline-warning" do %>
+                     <i class="fas fa-eye-slash"></i><span class="d-none d-sm-inline ms-1">非公開</span>
+                   <% end %>
+                 <% end %>
+             
+                 <%= link_to admin_recipe_path(recipe),
+                     method: :delete,
+                     data: { turbo_method: :delete, confirm: "このレシピを削除しますか？この操作は取り消せません。" },
+                     class: "btn btn-outline-danger" do %>
+                   <i class="fas fa-trash"></i><span class="d-none d-sm-inline ms-1">削除</span>
+                 <% end %>
+               </div>
+             </div>
+      
             </div>
           </div>
         <% end %>

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -95,17 +95,17 @@
         <ul class="nav nav-tabs card-header-tabs" id="userTabs" role="tablist">
           <li class="nav-item" role="presentation">
             <button class="nav-link active" id="recipes-tab" data-bs-toggle="tab" data-bs-target="#recipes" type="button" role="tab">
-              <i class="fas fa-book me-1"></i>レシピ (<%= @user_stats[:recipes_count] %>)
+              <i class="fas fa-book me-1"></i>レシピ (<%= (@user_stats || {})[:recipes_count].to_i %>)
             </button>
           </li>
           <li class="nav-item" role="presentation">
             <button class="nav-link" id="comments-tab" data-bs-toggle="tab" data-bs-target="#comments" type="button" role="tab">
-              <i class="fas fa-comments me-1"></i>コメント (<%= @user_stats[:comments_count] %>)
+              <i class="fas fa-comments me-1"></i>コメント (<%= (@user_stats || {})[:comments_count].to_i %>)
             </button>
           </li>
           <li class="nav-item" role="presentation">
             <button class="nav-link" id="reports-tab" data-bs-toggle="tab" data-bs-target="#reports" type="button" role="tab">
-              <i class="fas fa-flag me-1"></i>関連レポート (<%= @user_stats[:reports_count] %>)
+              <i class="fas fa-flag me-1"></i>関連レポート (<%= (@user_stats || {})[:reports_count].to_i %>)
             </button>
           </li>
         </ul>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -4,7 +4,7 @@
       <div class="card-body p-5">
         <h2 class="text-center mb-4">🍳 ログイン</h2>
 
-        <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
+        <%= form_for(resource, as: resource_name, url: session_path(resource_name), data: { turbo: false }) do |f| %>
           <div class="mb-3">
             <%= f.label :email, "メールアドレス", class: "form-label" %>
             <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "form-control" %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,7 +5,6 @@
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
-    
     <%= stylesheet_link_tag 'application', 'data-turbo-track': 'reload' %>
 
     <%= javascript_importmap_tags %>

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -1,0 +1,5 @@
+ja:
+  devise:
+    failure:
+      locked: "アカウントは停止中です。"
+      inactive: "アカウントが有効ではありません。"

--- a/db/migrate/20250926065752_add_suspend_fields_to_users.rb
+++ b/db/migrate/20250926065752_add_suspend_fields_to_users.rb
@@ -1,0 +1,18 @@
+class AddSuspendFieldsToUsers < ActiveRecord::Migration[7.1]
+  def change
+    # 既存なら追加しない
+    unless column_exists?(:users, :suspended)
+      add_column :users, :suspended, :boolean, default: false, null: false
+      add_index  :users, :suspended
+    end
+
+    unless column_exists?(:users, :suspended_until)
+      add_column :users, :suspended_until, :datetime
+      add_index  :users, :suspended_until
+    end
+
+    unless column_exists?(:users, :suspend_reason)
+      add_column :users, :suspend_reason, :text
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_09_24_192330) do
+ActiveRecord::Schema[7.1].define(version: 2025_09_26_065752) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -185,12 +185,14 @@ ActiveRecord::Schema[7.1].define(version: 2025_09_24_192330) do
     t.datetime "last_sign_in_at"
     t.inet "current_sign_in_ip"
     t.inet "last_sign_in_ip"
+    t.datetime "suspended_until"
     t.index ["admin"], name: "index_users_on_admin"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["last_sign_in_at"], name: "index_users_on_last_sign_in_at"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
     t.index ["suspend_until"], name: "index_users_on_suspend_until"
     t.index ["suspended"], name: "index_users_on_suspended"
+    t.index ["suspended_until"], name: "index_users_on_suspended_until"
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"


### PR DESCRIPTION
管理画面の修正と改善（4点）
① ユーザー詳細のエラー修正
管理画面からユーザー詳細に移動できない不具合を修正
データの取り方を整理して、必ず必要な情報を渡すようにした
レシピとコメントのページ分けも安定化

② アカウント停止機能の追加
管理者がユーザーを停止できるようにした（1日 / 3日 / 7日 / 30日 / 無期限）
停止されたユーザーはログインできない
すでにログイン中でも次のアクセスで強制ログアウトされる
停止理由も保存できる

③ 全ユーザーがログインできない不具合の修正
② の作業での弊害で全ユーザーがログインできないエラーを修正。
ログインフォームで Turbo を無効化し、エラー（422）が出ないようにした
通常ユーザーも問題なくログインできるようになった

④ レシピ一覧のUI改善
レシピ一覧の「詳細 / 公開切替 / 削除」ボタンが小さくて見えにくかったのを修正
ボタンにテキストを付けて見やすくした
余白を広げて押しやすくした

動作確認
ユーザー詳細に移動できる
停止したユーザーはログインできない
一般ユーザーは普通にログインできる
レシピ一覧のボタンが分かりやすく表示される

影響範囲
管理画面（ユーザー・レシピ・ログイン関連）
