### PR TITLE
管理・運用機能4

### DIFF
--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -1,6 +1,7 @@
 class Admin::BaseController < ApplicationController
   # 全ての管理者コントローラーで管理者認証を必須にする
   before_action :authenticate_admin!
+  before_action :require_admin!
   
   # 管理者専用レイアウトを使用
   layout 'admin'
@@ -30,4 +31,16 @@ class Admin::BaseController < ApplicationController
     flash[:alert] = "エラーが発生しました: #{error.message}"
     redirect_to admin_root_path
   end
+
+  def require_admin!
+    return if current_user&.admin?
+
+    respond_to do |f|
+      f.html        { redirect_to root_path, alert: '管理者権限が必要です' }
+      f.turbo_stream{ redirect_to root_path, alert: '管理者権限が必要です' }
+      f.json        { head :forbidden }
+      f.csv         { head :forbidden }
+    end
+  end
+  
 end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -8,43 +8,6 @@ class Admin::UsersController < Admin::BaseController
     @stats = Admin::UserStats.call
   end
 
-  # ユーザーCSVエクスポート
-  def export
-    scope = Admin::UsersQuery.new(filter_params).call
-
-    preload_assocs = []
-    preload_assocs << :recipes  if User.reflect_on_association(:recipes)
-    preload_assocs << :comments if User.reflect_on_association(:comments)
-    scope = scope.includes(preload_assocs) if preload_assocs.any?
-
-    require 'csv'
-    csv = CSV.generate(headers: true) do |c|
-      headers = %w[id name email admin created_at]
-      headers << 'recipes_count'   if User.reflect_on_association(:recipes)
-      headers << 'comments_count'  if User.reflect_on_association(:comments)
-      headers << 'last_sign_in_at' if User.column_names.include?('last_sign_in_at')
-      c << headers
-
-      scope.find_each do |u|
-        row = [
-          u.id,
-          (u.respond_to?(:display_name) ? u.display_name : u.name),
-          u.email,
-          u.admin?,
-          u.created_at
-        ]
-        row << (u.respond_to?(:recipes)  ? u.recipes.size  : nil) if headers.include?('recipes_count')
-        row << (u.respond_to?(:comments) ? u.comments.size : nil) if headers.include?('comments_count')
-        row << u[:last_sign_in_at] if headers.include?('last_sign_in_at')
-        c << row
-      end
-    end
-
-    send_data csv,
-              filename: "users_#{Time.zone.now.strftime('%Y%m%d_%H%M%S')}.csv",
-              type: 'text/csv'
-  end
-
   def show
     @user_stats = {
       recipes_count:    @user.recipes.count,
@@ -123,9 +86,35 @@ class Admin::UsersController < Admin::BaseController
     @user.update!(admin: true)
     redirect_back fallback_location: admin_users_path, notice: '管理者に昇格しました'
   end
+  
+  # ユーザーCSVエクスポート
+  require 'csv'
+  def export
+    scope = Admin::UsersQuery.new(filter_params).call
+  
+    bom = "\uFEFF" # UTF-8 BOM for Excel
+    filename = "users_#{Time.zone.now.strftime('%Y%m%d_%H%M')}_jst.csv"
+  
+    headers['Content-Type']        = 'text/csv; charset=UTF-8'
+    headers['Content-Disposition'] = "attachment; filename=\"#{filename}\""
+    headers['X-Accel-Buffering']   = 'no' # nginxのバッファ無効化（任意）
+  
+    self.response_body = Enumerator.new do |y|
+      y << bom
+      y << CSV.generate_line(%w[id name email role last_sign_in_at], force_quotes: true, row_sep: "\r\n")
+      scope.find_each(batch_size: 1000) do |u|
+        y << CSV.generate_line([
+          u.id,
+          csv_safe(u.name),
+          csv_safe(u.email),
+          (u.admin? ? 'admin' : 'user'),
+          u.last_sign_in_at&.in_time_zone('Asia/Tokyo')&.strftime('%Y-%m-%d %H:%M')
+        ], force_quotes: true, row_sep: "\r\n")
+      end
+    end
+  end
 
   private
-
   def set_user
     @user = User.find(params[:id])
   end
@@ -145,4 +134,14 @@ class Admin::UsersController < Admin::BaseController
     n = filter_params[:per_page].to_i
     [20, 50, 100].include?(n) ? n : 20
   end
+
+
+  CSV_INJECTION_PREFIX = /^(=|\+|-|@|\t)/
+  def csv_safe(val)
+    s = val.to_s.gsub(/\r\n|\r|\n/, ' ') # セル内改行→空白
+    s = "'#{s}" if s.match?(CSV_INJECTION_PREFIX) # 式扱い回避
+    s
+  end
+
+
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,5 @@
 class ApplicationController < ActionController::Base
+    
     # CSRF保護
     protect_from_forgery with: :exception
   
@@ -8,7 +9,7 @@ class ApplicationController < ActionController::Base
 
     # Deviseの画面（ログイン/新規登録/パスワード系）は認証スキップ
     skip_before_action :authenticate_user!, if: :devise_controller?
-    before_action :reject_suspended_user
+    before_action :enforce_suspension   #  停止ユーザーの強制ログアウト
   
     protected
     # Deviseのパラメータ設定（既存）
@@ -24,7 +25,7 @@ class ApplicationController < ActionController::Base
    def authenticate_admin!
      unless user_signed_in? && current_user.admin?
        flash[:alert] = "管理者権限が必要です"
-       redirect_to root_path
+       redirect_to root_path and return
      end
    end
    
@@ -37,7 +38,7 @@ class ApplicationController < ActionController::Base
    def current_user_admin?
      user_signed_in? && current_user.admin?
    end
-   
+
    # ヘルパーメソッドとしてビューでも使用可能にする
    helper_method :current_user_admin?
  
@@ -60,13 +61,13 @@ class ApplicationController < ActionController::Base
      end
    end
 
-   # アカウント停止か判断
-   def reject_suspended_user
-     return unless user_signed_in?
-     if current_user.suspended?
-       sign_out current_user
-       redirect_to new_user_session_path, alert: 'アカウントは停止中です。'
-     end
-   end
+   #  停止ユーザーの強制ログアウト
+   def enforce_suspension
+    return unless current_user
+    if current_user.suspended?  # モデルに true/false を返すメソッド
+      sign_out current_user
+      redirect_to new_user_session_path, alert: 'アカウントは停止中です。' and return
+    end
+  end
 
 end

--- a/app/views/admin/comments/index.html.erb
+++ b/app/views/admin/comments/index.html.erb
@@ -272,10 +272,11 @@
                               data-bs-toggle="dropdown">
                         <i class="fas fa-cog"></i>
                       </button>
+                      <!-- アクションボタン -->
                       <ul class="dropdown-menu">
                         <% if comment.hidden? %>
                           <li>
-                            <%= link_to show_admin_comment_path(comment), 
+                            <%= link_to unhide_admin_comment_path(comment), 
                                 method: :patch,
                                 class: "dropdown-item",
                                 data: { turbo_method: :patch } do %>


### PR DESCRIPTION
PR: 公開側の非公開対応／コメント管理のリンク修正／CSV実運用向け強化

公開側で非公開レシピを表示しないように修正
コメント管理の存在しないパスヘルパーを正しいものに変更
CSV出力の実運用性を少し改善（安全・Excel互換を意識）

変更点
Recipe に scope :published を追加
ページネーションは最後に一度だけ適用する形に整理
RecipesController#show に閲覧ガードを追加（非公開は投稿者/管理者のみ可）
管理画面 コメント一覧のドロップダウン
show_admin_comment_path → 削除
hide_admin_comment_path / unhide_admin_comment_path（PATCH）を使用
CSV 出力：強制クォート・BOM・CRLF の利用例をコメントで補足（既存ロジックは維持）

動作確認
非公開レシピが一覧/フィードに出ないこと
非公開レシピの直接URLは、投稿者/管理者のみ閲覧可
コメント一覧のドロップダウンから
「非表示にする」→ PATCH /admin/comments/:id/hide
「表示にする」→ PATCH /admin/comments/:id/unhide、が正しく動くこと

CSV を Excel/Googleスプレッドシートで開けること