### PR TITLE
一般ユーザー通報UI

### DIFF
--- a/app/controllers/admin/reports_controller.rb
+++ b/app/controllers/admin/reports_controller.rb
@@ -1,5 +1,5 @@
 class Admin::ReportsController < Admin::BaseController
-  before_action :set_report, only: [:show, :resolve, :dismiss, :investigate]
+  before_action :set_report, only: [:resolve, :dismiss, :investigate]
   before_action :set_admin_breadcrumbs
 
   def index
@@ -11,8 +11,28 @@ class Admin::ReportsController < Admin::BaseController
 
   def show
     @report = Report.includes(:reporter, :reportable, :admin_user).find(params[:id])
-    preload_reportables([@report])  # ← 1件でも統一（任意だが推奨）
-    add_breadcrumb("レポート詳細", admin_report_path(@report))
+  
+    # 同一報告者の他レポート
+    @reporter_reports =
+      if @report.reporter_id.present?
+        Report.where(reporter_id: @report.reporter_id)
+              .where.not(id: @report.id)
+              .order(created_at: :desc)
+              .limit(10)
+      else
+        Report.none
+      end
+  
+    # 同一対象への他レポート
+    @related_reports =
+      if @report.reportable_type.present? && @report.reportable_id.present?
+        Report.where(reportable_type: @report.reportable_type, reportable_id: @report.reportable_id)
+              .where.not(id: @report.id)
+              .order(created_at: :desc)
+              .limit(10)
+      else
+        Report.none
+      end
   end
 
   def resolve

--- a/app/controllers/admin/reports_controller.rb
+++ b/app/controllers/admin/reports_controller.rb
@@ -1,5 +1,5 @@
 class Admin::ReportsController < Admin::BaseController
-  before_action :set_report, only: [:resolve, :dismiss, :investigate]
+  before_action :set_report, only: [:resolve, :dismiss, :investigate, :update]
   before_action :set_admin_breadcrumbs
 
   def index
@@ -35,6 +35,36 @@ class Admin::ReportsController < Admin::BaseController
       end
   end
 
+  def update
+    if params.dig(:report, :admin_note).present?
+      # 管理者ノート保存
+      if @report.update(admin_note: params[:report][:admin_note], admin_user: current_user)
+        flash[:success] = 'ノートを保存しました'
+        return redirect_to admin_report_path(@report)
+      end
+    end
+
+    case params.dig(:report, :status).to_s
+    when 'investigating'
+      ok = @report.update(status: :investigating, admin_user: current_user)
+    when 'resolved'
+      ok = @report.resolve!(current_user, params[:admin_response]) rescue false
+    when 'dismissed'
+      ok = @report.dismiss!(current_user, params[:admin_response])  rescue false
+    when 'pending'
+      ok = @report.update(status: :pending, admin_user: current_user, admin_response: nil, resolved_at: nil)
+    else
+      ok = false
+      flash[:alert] = '不正なステータスです'
+    end
+
+    if ok
+      flash[:success] ||= '更新しました'
+    else
+      flash[:alert] ||= '更新に失敗しました'
+    end
+    redirect_to admin_report_path(@report)
+  end
   def resolve
     if @report.resolve!(current_user, params[:admin_response])
       log_admin_action("resolved report", @report)

--- a/app/controllers/admin/reports_controller.rb
+++ b/app/controllers/admin/reports_controller.rb
@@ -1,16 +1,17 @@
-# 
 class Admin::ReportsController < Admin::BaseController
   before_action :set_report, only: [:show, :resolve, :dismiss, :investigate]
   before_action :set_admin_breadcrumbs
 
   def index
-    @reports = build_reports_query
     @filter_params = filter_params
+    @reports = build_reports_query
+    preload_reportables(@reports)  # ← 型ごとの深い関連をプリロード
     @stats = report_stats
   end
 
   def show
     @report = Report.includes(:reporter, :reportable, :admin_user).find(params[:id])
+    preload_reportables([@report])  # ← 1件でも統一（任意だが推奨）
     add_breadcrumb("レポート詳細", admin_report_path(@report))
   end
 
@@ -35,7 +36,7 @@ class Admin::ReportsController < Admin::BaseController
   end
 
   def investigate
-    if @report.update(status: 'investigating', admin_user: current_user)
+    if @report.update(status: :investigating, admin_user: current_user) # ← シンボルで統一
       log_admin_action("started investigating report", @report)
       flash[:info] = 'レポートの調査を開始しました'
     else
@@ -45,36 +46,50 @@ class Admin::ReportsController < Admin::BaseController
   end
 
   private
+  def preload_reportables(reports)
+    recipes  = []
+    comments = []
+  
+    reports.each do |r|
+      case r.reportable_type
+      when "Recipe"  then recipes  << r.reportable
+      when "Comment" then comments << r.reportable
+      end
+    end
+  
+    # Rails 7.1+ の正しい呼び方（配列が空でもOK）
+    ActiveRecord::Associations::Preloader.new(
+      records: recipes,
+      associations: :user
+    ).call
+  
+    ActiveRecord::Associations::Preloader.new(
+      records: comments,
+      associations: [:user, :recipe]
+    ).call
+  end
 
   def set_report
     @report = Report.find(params[:id])
   end
 
   def build_reports_query
-    reports = Report.includes(:reporter, :reportable, :admin_user)
-    
-    # ステータスでフィルタリング
+    reports = Report.includes(:reporter, :reportable, :admin_user)  # 深い先はpreloadで
+
     reports = reports.where(status: params[:status]) if params[:status].present?
-    
-    # 報告対象のタイプでフィルタリング
     reports = reports.where(reportable_type: params[:reportable_type]) if params[:reportable_type].present?
-    
-    # 期間でフィルタリング
+
     if params[:date_from].present?
       reports = reports.where('created_at >= ?', Date.parse(params[:date_from]))
     end
-    
     if params[:date_to].present?
       reports = reports.where('created_at <= ?', Date.parse(params[:date_to]).end_of_day)
     end
-    
-    # ソート
-    sort_column = params[:sort].presence || 'created_at'
+
+    sort_column   = params[:sort].presence || 'created_at'
     sort_direction = params[:direction].presence || 'desc'
-    
     reports = reports.order("#{sort_column} #{sort_direction}")
-    
-    # ページネーション
+
     reports.page(params[:page]).per(20)
   end
 
@@ -101,6 +116,6 @@ class Admin::ReportsController < Admin::BaseController
   end
 
   def add_breadcrumb(name, path)
-    @breadcrumbs << { name: name, path: path }
+    @breadcrumbs <<({ name: name, path: path })
   end
 end

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -20,45 +20,25 @@ class ReportsController < ApplicationController
       format.js   # Ajax対応を続けるなら残す
     end
   end
-
   def create
-    # 既存あればそれを返し、新規は作らない（UX最適化）
-    @report = current_user.reports.find_or_initialize_by(reportable: @reportable)
+    # × current_user.reports.find_or_initialize_by(...)
+    @report = current_user.submitted_reports.find_or_initialize_by(reportable: @reportable)
     @report.assign_attributes(report_params)
-
-    # 重複チェック（UIガード）
+  
     if @report.persisted?
       flash[:alert] = 'この項目は既にレポート済みです'
       return redirect_back(fallback_location: @reportable)
     end
-
-    # 自分自身/自分の投稿は通報不可（任意）
-    if reporting_own_resource?
-      flash[:alert] = '自身や自分の投稿はレポートできません'
-      return redirect_back(fallback_location: @reportable)
+  
+    if @report.save
+      flash[:success] = 'レポートを送信しました。内容を確認後、対応いたします。'
+      redirect_back(fallback_location: @reportable)
+    else
+      render :new, status: :unprocessable_content  # Rack 3 対応
     end
-
-    respond_to do |format|
-      begin
-        if @report.save
-          format.html do
-            flash[:success] = 'レポートを送信しました。内容を確認後、対応いたします。'
-            redirect_back(fallback_location: @reportable)
-          end
-          format.js { flash.now[:success] = 'レポートを送信しました' }
-        else
-          format.html { render :new, status: :unprocessable_entity }
-          format.js   { render :new, status: :unprocessable_entity }
-        end
-      rescue ActiveRecord::RecordNotUnique
-        # 競合で同時に作られた場合の最終防衛
-        format.html do
-          flash[:info] = 'この項目は既にレポート済みです'
-          redirect_back(fallback_location: @reportable)
-        end
-        format.js { head :conflict }
-      end
-    end
+  rescue ActiveRecord::RecordNotUnique
+    flash[:info] = 'この項目は既にレポート済みです'
+    redirect_back(fallback_location: @reportable)
   end
 
   private

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -3,53 +3,68 @@ class ReportsController < ApplicationController
   before_action :set_reportable, only: [:new, :create]
 
   def new
-    @report = Report.new
-    
-    # 既にレポート済みかチェック
+    # 既に通報済みならフォームは出さずに戻す
     if @reportable.reported_by?(current_user)
       flash[:info] = 'この項目は既にレポート済みです'
-      redirect_back_or_to(@reportable)
-      return
+      return redirect_back(fallback_location: @reportable)
     end
 
+    # 自分自身/自分の投稿は通報不可（任意）
+    if reporting_own_resource?
+      flash[:alert] = '自身や自分の投稿はレポートできません'
+      return redirect_back(fallback_location: @reportable)
+    end
+    @report = Report.new
     respond_to do |format|
       format.html
-      format.js   # Ajax対応
+      format.js   # Ajax対応を続けるなら残す
     end
   end
 
   def create
-    @report = Report.new(report_params)
-    @report.reporter = current_user
-    @report.reportable = @reportable
+    # 既存あればそれを返し、新規は作らない（UX最適化）
+    @report = current_user.reports.find_or_initialize_by(reportable: @reportable)
+    @report.assign_attributes(report_params)
 
-    # 重複チェック
-    if @reportable.reported_by?(current_user)
+    # 重複チェック（UIガード）
+    if @report.persisted?
       flash[:alert] = 'この項目は既にレポート済みです'
-      redirect_back_or_to(@reportable)
-      return
+      return redirect_back(fallback_location: @reportable)
+    end
+
+    # 自分自身/自分の投稿は通報不可（任意）
+    if reporting_own_resource?
+      flash[:alert] = '自身や自分の投稿はレポートできません'
+      return redirect_back(fallback_location: @reportable)
     end
 
     respond_to do |format|
-      if @report.save
+      begin
+        if @report.save
+          format.html do
+            flash[:success] = 'レポートを送信しました。内容を確認後、対応いたします。'
+            redirect_back(fallback_location: @reportable)
+          end
+          format.js { flash.now[:success] = 'レポートを送信しました' }
+        else
+          format.html { render :new, status: :unprocessable_entity }
+          format.js   { render :new, status: :unprocessable_entity }
+        end
+      rescue ActiveRecord::RecordNotUnique
+        # 競合で同時に作られた場合の最終防衛
         format.html do
-          flash[:success] = 'レポートを送信しました。内容を確認後、対応いたします。'
-          redirect_back_or_to(@reportable)
+          flash[:info] = 'この項目は既にレポート済みです'
+          redirect_back(fallback_location: @reportable)
         end
-        format.js do
-          flash.now[:success] = 'レポートを送信しました'
-        end
-      else
-        format.html { render :new }
-        format.js   { render :new }
+        format.js { head :conflict }
       end
     end
   end
 
   private
+
   def set_reportable
     @reportable = find_reportable
-    
     unless @reportable
       flash[:alert] = 'レポート対象が見つかりません'
       redirect_to root_path
@@ -57,15 +72,29 @@ class ReportsController < ApplicationController
   end
 
   def find_reportable
-    # ポリモーフィック関連の対象を特定
-    if params[:recipe_id]
-      Recipe.find_by(id: params[:recipe_id])
-    elsif params[:comment_id]
-      Comment.find_by(id: params[:comment_id])
-    elsif params[:user_id]
-      User.find_by(id: params[:user_id])
+    # ① 汎用パラメータ（reports_path?reportable_type=Recipe&reportable_id=1）
+    if params[:reportable_type].present? && params[:reportable_id].present?
+      klass = params[:reportable_type].to_s.safe_constantize
+      return klass&.find_by(id: params[:reportable_id]) if klass
+    end
+
+    # ② 既存の個別ショートカット
+    return Recipe.find_by(id: params[:recipe_id])   if params[:recipe_id]
+    return Comment.find_by(id: params[:comment_id]) if params[:comment_id]
+    return User.find_by(id: params[:user_id])       if params[:user_id]
+
+    nil
+  end
+
+  # 自分自身/自分の投稿を通報しようとしてないか（任意ガード）
+  def reporting_own_resource?
+    case @reportable
+    when User
+      @reportable.id == current_user.id
+    when Recipe, Comment
+      @reportable.respond_to?(:user_id) && @reportable.user_id == current_user.id
     else
-      nil
+      false
     end
   end
 

--- a/app/helpers/admin/reports_helper.rb
+++ b/app/helpers/admin/reports_helper.rb
@@ -1,0 +1,13 @@
+module Admin::ReportsHelper
+  def report_owner_name(report)
+    return '削除済み' unless report&.reportable
+
+    owner =
+      case report.reportable
+      when Recipe, Comment then report.reportable&.user
+      when User            then report.reportable
+      end
+
+    owner&.respond_to?(:display_name) ? owner.display_name : (owner&.name || '不明')
+  end
+end

--- a/app/models/concerns/reportable.rb
+++ b/app/models/concerns/reportable.rb
@@ -9,8 +9,7 @@ module Reportable
   
   # このモデルが特定のユーザーによってレポートされているかチェック
   def reported_by?(user)
-    return false unless user
-    reports.exists?(reporter: user)
+    reports.where(reporter: user).exists?
   end
   
   # このモデルに対するレポート数を取得
@@ -27,4 +26,5 @@ module Reportable
   def pending_reports_count
     reports.pending.count
   end
+
 end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -2,13 +2,12 @@ class Report < ApplicationRecord
     # ===== 関連付け =====
     belongs_to :reporter, class_name: 'User'
     belongs_to :reportable, polymorphic: true
-    belongs_to :admin_user, class_name: 'User', optional: true
+    belongs_to :admin_user, class_name: "User", foreign_key: :admin_user_id, optional: true
     
     # ===== バリデーション =====
-    validates :reason, presence: true, length: { minimum: 10, maximum: 500 }
-    validates :description, length: { maximum: 1000 }
-    validates :status, inclusion: { in: %w[pending investigating resolved dismissed] }
-    
+    validates :reason, presence: true   #（reasonはenum。長さチェックはdescriptionに）
+    validates :description, presence: true, length: { minimum: 10, maximum: 1000 }
+
     # 同じユーザーが同じ対象に重複レポートすることを防ぐ
     validates :reporter_id, uniqueness: { 
       scope: [:reportable_type, :reportable_id],
@@ -16,24 +15,23 @@ class Report < ApplicationRecord
     }
     
     # ===== Enum定義 =====
-    enum status: {
-      pending: 'pending',           # 未対応
-      investigating: 'investigating', # 調査中
-      resolved: 'resolved',         # 解決済み
-      dismissed: 'dismissed'        # 却下
-    }
+    enum status: { pending: 0, investigating: 1, resolved: 2, dismissed: 3 }
+    enum reason: { spam: 0, inappropriate: 1, copyright: 2, other: 3 }
     
     # ===== スコープ =====
     scope :recent, -> { order(created_at: :desc) }
-    scope :by_status, ->(status) { where(status: status) if status.present? }
-    scope :by_reportable_type, ->(type) { where(reportable_type: type) if type.present? }
+    scope :with_status, ->(s) { s.present? ? where(status: statuses[s]) : all }
+    scope :by_reportable_type, ->(type) { type.present? ? where(reportable_type: type) : all }
     
     # ===== インスタンスメソッド =====
     
     # レポートを解決済みにする
     def resolve!(admin, response = nil)
+      raise ArgumentError, "adminが必要です" if admin.blank?
+      raise StateError, "pending/investigating以外からは解決にできません" unless pending? || investigating?
+  
       update!(
-        status: 'resolved',
+        status: :resolved,
         admin_user: admin,
         admin_response: response,
         resolved_at: Time.current
@@ -78,8 +76,12 @@ class Report < ApplicationRecord
       end
     end
     
-    # 対応済みかどうか
-    def resolved?
+    # 対応済みか（解決 or 却下）
+    def resolved_or_dismissed?
       resolved? || dismissed?
+    end
+    # 便利メソッド（UI制御で利用）
+    def self.already_reported?(user, record)
+      where(reporter: user, reportable: record).exists?
     end
 end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -1,87 +1,84 @@
 class Report < ApplicationRecord
-    # ===== 関連付け =====
-    belongs_to :reporter, class_name: 'User'
-    belongs_to :reportable, polymorphic: true
-    belongs_to :admin_user, class_name: "User", foreign_key: :admin_user_id, optional: true
-    
-    # ===== バリデーション =====
-    validates :reason, presence: true   #（reasonはenum。長さチェックはdescriptionに）
-    validates :description, presence: true, length: { minimum: 10, maximum: 1000 }
+  # ===== Associations =====
+  belongs_to :reporter,   class_name: 'User', inverse_of: :submitted_reports
+  belongs_to :reportable, polymorphic: true
+  belongs_to :admin_user, class_name: 'User', foreign_key: :admin_user_id, optional: true
 
-    # 同じユーザーが同じ対象に重複レポートすることを防ぐ
-    validates :reporter_id, uniqueness: { 
-      scope: [:reportable_type, :reportable_id],
-      message: "既にこの項目をレポートしています"
-    }
-    
-    # ===== Enum定義 =====
-    enum status: { pending: 0, investigating: 1, resolved: 2, dismissed: 3 }
-    enum reason: { spam: 0, inappropriate: 1, copyright: 2, other: 3 }
-    
-    # ===== スコープ =====
-    scope :recent, -> { order(created_at: :desc) }
-    scope :with_status, ->(s) { s.present? ? where(status: statuses[s]) : all }
-    scope :by_reportable_type, ->(type) { type.present? ? where(reportable_type: type) : all }
-    
-    # ===== インスタンスメソッド =====
-    
-    # レポートを解決済みにする
-    def resolve!(admin, response = nil)
-      raise ArgumentError, "adminが必要です" if admin.blank?
-      raise StateError, "pending/investigating以外からは解決にできません" unless pending? || investigating?
-  
-      update!(
-        status: :resolved,
-        admin_user: admin,
-        admin_response: response,
-        resolved_at: Time.current
-      )
+  # ===== Validations =====
+  validates :reason, presence: true
+  validates :description, presence: true, length: { minimum: 10, maximum: 1000 }
+  validates :reporter_id, uniqueness: {
+    scope: [:reportable_type, :reportable_id],
+    message: "既にこの項目をレポートしています"
+  }
+
+  # ===== Enums =====
+  enum status: { pending: 0, investigating: 1, resolved: 2, dismissed: 3 }
+  enum reason: { spam: 0, inappropriate: 1, copyright: 2, other: 3 }
+
+  # ===== Scopes =====
+  scope :recent, -> { order(created_at: :desc) }
+  scope :with_status, ->(s) {
+    s.present? && statuses.key?(s.to_s) ? where(status: statuses[s]) : all
+  }
+  scope :by_reportable_type, ->(type) { type.present? ? where(reportable_type: type) : all }
+
+  # ===== Defaults =====
+  after_initialize do
+    self.status ||= :pending if new_record?
+  end
+
+  # ===== State Transitions =====
+  def resolve!(admin, response = nil)
+    raise ArgumentError, "adminが必要です" if admin.blank?
+    raise StateError, "pending/investigating以外からは解決にできません" unless pending? || investigating?
+
+    update!(
+      status: :resolved,
+      admin_user: admin,
+      admin_response: response,
+      resolved_at: Time.current
+    )
+  end
+
+  def dismiss!(admin, response = nil)
+    raise ArgumentError, "adminが必要です" if admin.blank?
+    raise StateError, "pending/investigating以外からは却下にできません" unless pending? || investigating?
+
+    update!(
+      status: :dismissed,  # ← シンボルで統一
+      admin_user: admin,
+      admin_response: response,
+      resolved_at: Time.current
+    )
+  end
+
+  # ===== Helpers =====
+  def reportable_type_japanese
+    case reportable_type
+    when 'Recipe'  then 'レシピ'
+    when 'Comment' then 'コメント'
+    when 'User'    then 'ユーザー'
+    else reportable_type
     end
-    
-    # レポートを却下する
-    def dismiss!(admin, response = nil)
-      update!(
-        status: 'dismissed',
-        admin_user: admin,
-        admin_response: response,
-        resolved_at: Time.current
-      )
+  end
+
+  def reportable_title
+    case reportable_type
+    when 'Recipe'  then reportable&.title
+    when 'Comment' then reportable&.content.to_s.truncate(50)
+    when 'User'    then reportable&.name
+    else "不明"
     end
-    
-    # レポート対象の種類を日本語で取得
-    def reportable_type_japanese
-      case reportable_type
-      when 'Recipe'
-        'レシピ'
-      when 'Comment' 
-        'コメント'
-      when 'User'
-        'ユーザー'
-      else
-        reportable_type
-      end
-    end
-    
-    # レポート対象のタイトルを取得
-    def reportable_title
-      case reportable_type
-      when 'Recipe'
-        reportable.title
-      when 'Comment'
-        reportable.content.truncate(50)
-      when 'User'
-        reportable.name
-      else
-        "不明"
-      end
-    end
-    
-    # 対応済みか（解決 or 却下）
-    def resolved_or_dismissed?
-      resolved? || dismissed?
-    end
-    # 便利メソッド（UI制御で利用）
-    def self.already_reported?(user, record)
-      where(reporter: user, reportable: record).exists?
-    end
+  end
+
+  def resolved_or_dismissed?
+    resolved? || dismissed?
+  end
+
+  def self.already_reported?(user, record)
+    where(reporter: user, reportable: record).exists?
+  end
+
+  class StateError < StandardError; end
 end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -4,9 +4,10 @@ class Report < ApplicationRecord
   belongs_to :reportable, polymorphic: true
   belongs_to :admin_user, class_name: 'User', foreign_key: :admin_user_id, optional: true
 
+
   # ===== Validations =====
   validates :reason, presence: true
-  validates :description, presence: true, length: { minimum: 10, maximum: 1000 }
+  validates :description, length: { minimum: 10, maximum: 1000 }, allow_blank: true
   validates :reporter_id, uniqueness: {
     scope: [:reportable_type, :reportable_id],
     message: "既にこの項目をレポートしています"

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -24,9 +24,21 @@ class Report < ApplicationRecord
   scope :by_reportable_type, ->(type) { type.present? ? where(reportable_type: type) : all }
 
   # ===== Defaults =====
-  after_initialize do
-    self.status ||= :pending if new_record?
-  end
+  after_initialize :set_default_status, if: :new_record?
+
+  STATUS_COLOR = {
+    'pending'       => 'warning',
+    'investigating' => 'info',
+    'resolved'      => 'success',
+    'dismissed'     => 'secondary'
+  }.freeze
+
+  STATUS_JA = {
+    'pending'       => '未対応',
+    'investigating' => '調査中',
+    'resolved'      => '対応済み',
+    'dismissed'     => '却下'
+  }.freeze
 
   # ===== State Transitions =====
   def resolve!(admin, response = nil)
@@ -80,5 +92,26 @@ class Report < ApplicationRecord
     where(reporter: user, reportable: record).exists?
   end
 
+  def status_color
+    STATUS_COLOR[status] || 'secondary'
+  end
+
+  def status_japanese
+    STATUS_JA[status] || '未設定'
+  end
+
+  def reportable_admin_path
+    return nil unless reportable
+    helpers = Rails.application.routes.url_helpers
+    helpers.polymorphic_path([:admin, reportable])
+  rescue NoMethodError, ArgumentError
+    helpers.polymorphic_path(reportable) rescue nil
+  end
+
   class StateError < StandardError; end
+
+  private
+  def set_default_status
+    self.status ||= :pending
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,5 @@
 class User < ApplicationRecord
-  include Reportable
+  include Reportable  # has_many :reports, as: :reportable （= 通報“される”側）   
 
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable,
@@ -14,7 +14,8 @@ class User < ApplicationRecord
   has_many :comments, dependent: :destroy
   has_one_attached :avatar
   # レポート機能の関連付け（追加）
-  has_many :sent_reports, class_name: 'Report', foreign_key: 'reporter_id', dependent: :destroy
+            # 通報“する”側は別名にする（衝突回避）
+  has_many :submitted_reports, class_name: "Report", foreign_key: :reporter_id, inverse_of: :reporter, dependent: :nullify
   has_many :admin_handled_reports, class_name: 'Report', foreign_key: 'admin_user_id', dependent: :nullify
 
 

--- a/app/views/admin/reports/index.html.erb
+++ b/app/views/admin/reports/index.html.erb
@@ -219,15 +219,15 @@
                     </span>
                   </div>
                   <div class="mt-1">
-                    <strong><%= truncate(report.reportable_title, length: 40) %></strong>
+                    <strong><%= truncate(report.reportable_title.to_s, length: 40) %></strong>
                   </div>
                   <% if report.reportable_type == 'Recipe' %>
                     <small class="text-muted">
-                      by <%= report.reportable.user.display_name %>
+                      by <%= report.reportable&.user&.display_name || "不明" %>
                     </small>
                   <% elsif report.reportable_type == 'Comment' %>
                     <small class="text-muted">
-                      on <%= truncate(report.reportable.recipe.title, length: 20) %>
+                      on <%= truncate(report.reportable&.recipe&.title.to_s, length: 20) %>
                     </small>
                   <% end %>
                 </td>
@@ -308,12 +308,12 @@
                     <% elsif report.investigating? %>
                       <small class="text-muted">
                         <i class="fas fa-user me-1"></i>
-                        <%= report.admin_user.display_name %>が調査中
+                        <%= report.admin_user&.display_name || "未割り当て" %> が調査中
                       </small>
                     <% else %>
                       <small class="text-muted">
                         <i class="fas fa-user me-1"></i>
-                        <%= report.admin_user.display_name %>が対応済み
+                        <%= report.admin_user&.display_name || "未割り当て" %> が対応済み
                       </small>
                     <% end %>
                   </div>
@@ -330,7 +330,7 @@
           <div class="text-muted">
             <%= page_entries_info @reports, entry_name: 'レポート' %>
           </div>
-          <%= paginate @reports, theme: 'bootstrap' %>
+          <%= paginate @reports, theme: 'bootstrap4' %>
         </div>
       </div>
     <% else %>

--- a/app/views/admin/reports/show.html.erb
+++ b/app/views/admin/reports/show.html.erb
@@ -23,15 +23,20 @@
       <div class="card-header d-flex justify-content-between align-items-start">
         <div>
           <h5 class="mb-1">
-            <span class="badge bg-<%= @report.status_color %> me-2">
-              <%= @report.status_japanese %>
+            <span class="badge bg-<%= @report.respond_to?(:status_color) ? @report.status_color : 'secondary' %> me-2">
+              <%= @report.respond_to?(:status_japanese) ? @report.status_japanese : '未設定' %>
             </span>
+            
             <%= @report.reportable_type_japanese %>への報告
           </h5>
+
           <small class="text-muted">
-            <i class="fas fa-clock me-1"></i>
-            <%= @report.created_at.strftime("%Y年%m月%d日 %H:%M") %>
-            (<%= time_ago_in_words(@report.created_at) %>前)
+            <% owner =
+                 case @report.reportable
+                 when Recipe, Comment then @report.reportable&.user
+                 when User            then @report.reportable
+                 end %>
+            by <%= owner&.respond_to?(:display_name) ? owner.display_name : (owner&.name || '不明') %>
           </small>
         </div>
         <div>
@@ -57,14 +62,13 @@
               <% end %>
               <div>
                 <div class="fw-medium">
-                  <%= link_to @report.reporter.display_name, admin_user_path(@report.reporter), 
-                      class: "text-decoration-none" %>
-                </div>
-                <small class="text-muted"><%= @report.reporter.email %></small>
-                <div>
-                  <span class="badge bg-light text-dark">
-                    登録: <%= @report.reporter.created_at.strftime("%Y/%m/%d") %>
-                  </span>
+                  <% if @report.reportable.present? %>
+                    <%= link_to @report.reportable_title,
+                                polymorphic_path([:admin, @report.reportable]),
+                                class: "text-decoration-none" %>
+                  <% else %>
+                    <span class="text-muted"><%= @report.reportable_title %>（削除済み）</span>
+                  <% end %>
                 </div>
               </div>
             </div>
@@ -109,7 +113,7 @@
                       class: "text-decoration-none" %>
                 </div>
                 <small class="text-muted">
-                  by <%= @report.reportable_user_name %>
+                  by <%= report_owner_name(@report) %>
                 </small>
                 <div class="mt-1">
                   <span class="badge bg-light text-dark">
@@ -173,12 +177,12 @@
           </div>
         <% end %>
 
-        <% if @report.admin_note.present? %>
+        <% if @report.admin_response.present? %>
           <div class="bg-light p-3 rounded">
             <small class="text-muted d-block mb-2">
               <%= @report.updated_at.strftime("%Y年%m月%d日 %H:%M") %>更新
             </small>
-            <div style="white-space: pre-line;"><%= @report.admin_note %></div>
+            <div style="white-space: pre-line;"><%= @report.admin_response %></div>
           </div>
         <% end %>
       </div>
@@ -333,7 +337,7 @@
           <h6 class="text-muted">統計</h6>
           <ul class="list-unstyled small">
             <li>報告者レポート数: <%= @reporter_reports.count %>件</li>
-            <li>対象レポート数: <%= @target_reports.count %>件</li>
+            <li>対象レポート数: <%= @related_reports.count %>件</li> </li>
             <li>今月のレポート数: <%= Report.where(created_at: Time.current.beginning_of_month..Time.current.end_of_month).count %>件</li>
           </ul>
         </div>

--- a/app/views/admin/reports/show.html.erb
+++ b/app/views/admin/reports/show.html.erb
@@ -204,54 +204,33 @@
           <label class="form-label">ステータス変更</label>
           <div class="d-grid gap-2">
             <% unless @report.investigating? %>
-              <%= link_to admin_report_path(@report), 
-                  method: :patch,
-                  params: { report: { status: :investigating } },
-                  class: "btn btn-outline-info btn-sm",
-                  data: { 
-                    turbo_method: :patch,
-                    confirm: "ステータスを「調査中」に変更しますか？"
-                  } do %>
+                <%= link_to admin_report_path(@report, report: { status: 'investigating' }),
+                class: "btn btn-outline-info btn-sm",
+                data: { turbo_method: :patch, turbo_confirm: "ステータスを「調査中」に変更しますか？" } do %>
                 <i class="fas fa-search me-1"></i>調査中にする
               <% end %>
             <% end %>
 
             <% unless @report.resolved? %>
-              <%= link_to admin_report_path(@report), 
-                  method: :patch,
-                  params: { report: { status: :resolved } },
-                  class: "btn btn-outline-success btn-sm",
-                  data: { 
-                    turbo_method: :patch,
-                    confirm: "ステータスを「解決済み」に変更しますか？"
-                  } do %>
+                <%= link_to admin_report_path(@report, report: { status: 'investigating' }),
+                class: "btn btn-outline-info btn-sm",
+                data: { turbo_method: :patch, turbo_confirm: "ステータスを「調査中」に変更しますか？" } do %>
                 <i class="fas fa-check me-1"></i>解決済みにする
               <% end %>
             <% end %>
 
             <% unless @report.dismissed? %>
-              <%= link_to admin_report_path(@report), 
-                  method: :patch,
-                  params: { report: { status: :dismissed } },
+              <%= link_to admin_report_path(@report, report: { status: 'dismissed' }),
                   class: "btn btn-outline-secondary btn-sm",
-                  data: { 
-                    turbo_method: :patch,
-                    confirm: "このレポートを却下しますか？"
-                  } do %>
+                  data: { turbo_method: :patch, turbo_confirm: "このレポートを却下しますか？" } do %>
                 <i class="fas fa-times me-1"></i>却下する
               <% end %>
             <% end %>
 
-            <% if @report.pending? %>
-              <%= link_to admin_report_path(@report), 
-                  method: :patch,
-                  params: { report: { status: :pending } },
+            <% unless @report.pending? %> <!-- if -> unless に修正 -->
+              <%= link_to admin_report_path(@report, report: { status: 'pending' }),
                   class: "btn btn-outline-warning btn-sm",
-                  data: { 
-                    turbo_method: :patch,
-                    confirm: "ステータスを「未対応」に戻しますか？"
-                  } do %>
-                <i class="fas fa-undo me-1"></i>未対応に戻す
+                  data: { turbo_method: :patch, turbo_confirm: "ステータスを「未対応」に戻しますか？" } do %>
               <% end %>
             <% end %>
           </div>

--- a/app/views/admin/reports/show.html.erb
+++ b/app/views/admin/reports/show.html.erb
@@ -117,7 +117,7 @@
                 </small>
                 <div class="mt-1">
                   <span class="badge bg-light text-dark">
-                    作成: <%= @report.reportable.created_at.strftime("%Y/%m/%d") %>
+                    作成: <%= @report.reportable&.created_at&.strftime("%Y/%m/%d") || '-' %>
                   </span>
                 </div>
               </div>
@@ -204,21 +204,21 @@
           <label class="form-label">ステータス変更</label>
           <div class="d-grid gap-2">
             <% unless @report.investigating? %>
-                <%= link_to admin_report_path(@report, report: { status: 'investigating' }),
-                class: "btn btn-outline-info btn-sm",
-                data: { turbo_method: :patch, turbo_confirm: "ステータスを「調査中」に変更しますか？" } do %>
+              <%= link_to admin_report_path(@report, report: { status: 'investigating' }),
+                  class: "btn btn-outline-info btn-sm",
+                  data: { turbo_method: :patch, turbo_confirm: "ステータスを「調査中」に変更しますか？" } do %>
                 <i class="fas fa-search me-1"></i>調査中にする
               <% end %>
             <% end %>
-
+          
             <% unless @report.resolved? %>
-                <%= link_to admin_report_path(@report, report: { status: 'investigating' }),
-                class: "btn btn-outline-info btn-sm",
-                data: { turbo_method: :patch, turbo_confirm: "ステータスを「調査中」に変更しますか？" } do %>
+              <%= link_to admin_report_path(@report, report: { status: 'resolved' }),
+                  class: "btn btn-outline-success btn-sm",
+                  data: { turbo_method: :patch, turbo_confirm: "ステータスを「解決済み」に変更しますか？" } do %>
                 <i class="fas fa-check me-1"></i>解決済みにする
               <% end %>
             <% end %>
-
+          
             <% unless @report.dismissed? %>
               <%= link_to admin_report_path(@report, report: { status: 'dismissed' }),
                   class: "btn btn-outline-secondary btn-sm",
@@ -226,11 +226,12 @@
                 <i class="fas fa-times me-1"></i>却下する
               <% end %>
             <% end %>
-
-            <% unless @report.pending? %> <!-- if -> unless に修正 -->
+          
+            <% unless @report.pending? %>
               <%= link_to admin_report_path(@report, report: { status: 'pending' }),
                   class: "btn btn-outline-warning btn-sm",
                   data: { turbo_method: :patch, turbo_confirm: "ステータスを「未対応」に戻しますか？" } do %>
+                <i class="fas fa-undo me-1"></i>未対応に戻す
               <% end %>
             <% end %>
           </div>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -3,11 +3,13 @@
   <head>
     <title>CookShare - 管理者画面</title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
+    <meta name="turbo-cache-control" content="no-cache"> <!-- Turboのキャッシュを無効化 -->
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
     
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_importmap_tags %>
+
     
   </head>
 

--- a/app/views/recipes/show.html.erb
+++ b/app/views/recipes/show.html.erb
@@ -226,6 +226,18 @@
                     </small>
                   </div>
                 </div>
+                <!-- 通報ボタン -->
+                <div class="btn-group">
+                  <% if user_signed_in? && current_user != comment.user %>
+                    <% if !comment.reported_by?(current_user) %>
+                      <%= link_to "このコメントを通報",
+                          new_report_path(comment_id: comment.id),
+                          class: "btn btn-outline-danger btn-sm",
+                          "aria-label": "Report this comment" %>
+                    <% else %>
+                      <button class="btn btn-outline-secondary btn-sm" disabled>通報済み</button>
+                    <% end %>
+                  <% end %>
 
                 <% if current_user == comment.user %>
                   <%= link_to "削除", recipe_comment_path(@recipe, comment),
@@ -260,7 +272,20 @@
     </div>
   </div>
 </div>
-
+<!-- 通報ボタン -->
+<% unless @recipe.user == current_user %>
+  <% if user_signed_in? && !@recipe.reported_by?(current_user) %>
+    <%= link_to t("reports.report_this"),
+        new_report_path(recipe_id: @recipe.id),
+        class: "btn btn-outline-danger btn-sm", "aria-label": t("reports.aria_report_recipe") %>
+  <% end %>
+<% end %>
 <div class="text-center mt-4">
   <%= link_to "レシピ一覧に戻る", recipes_path, class: "btn btn-outline-primary" %>
+</div>
+<% if user_signed_in? %>
+<%= link_to "マイページ", user_path(current_user), class: "btn btn-primary" %>
+<% end %>
+
+<%= link_to "投稿者ページ", user_path(@recipe.user), class: "btn btn-outline-secondary" %>
 </div>

--- a/app/views/reports/new.html.erb
+++ b/app/views/reports/new.html.erb
@@ -1,2 +1,39 @@
-<h1>Reports#new</h1>
-<p>Find me in app/views/reports/new.html.erb</p>
+<div class="container mt-4">
+  <h2>通報フォーム</h2>
+  <p class="text-muted">
+    対象: <%= @reportable.class.model_name.human %>
+  </p>
+
+    <%# ← 先に戻り先を決める %>
+    <% back_path =
+    case @reportable
+    when Recipe  then recipe_path(@reportable)
+    when Comment then recipe_path(@reportable.recipe)
+    when User    then user_path(@reportable)
+    else root_path
+    end
+  %>
+
+  <%= form_with model: @report, url: reports_path(
+        reportable_type: @reportable.class.name,
+        reportable_id: @reportable.id
+      ), class: "needs-validation" do |f| %>
+
+    <div class="mb-3">
+      <%= f.label :reason, t("activerecord.attributes.report.reason"), class: "form-label" %>
+      <%= f.select :reason, Report.reasons.keys.map { |k|
+            [t("activerecord.attributes.report.reasons.#{k}"), k]
+          }, {}, class: "form-select", required: true, aria: { describedby: "reasonHelp" } %>
+      <div id="reasonHelp" class="form-text"><%= t("reports.reason_help") %></div>
+    </div>
+
+    <div class="mb-3">
+      <%= f.label :description, t("activerecord.attributes.report.description"), class: "form-label" %>
+      <%= f.text_area :description, rows: 5, class: "form-control",
+            placeholder: t("reports.description_placeholder"), required: true %>
+    </div>
+
+    <%= f.submit t("reports.submit"), class: "btn btn-danger" %>
+    <%= link_to t("common.cancel"), back_path,   class: "btn btn-secondary" %>
+  <% end %>
+</div>

--- a/app/views/reports/new.html.erb
+++ b/app/views/reports/new.html.erb
@@ -4,8 +4,8 @@
     対象: <%= @reportable.class.model_name.human %>
   </p>
 
-    <%# ← 先に戻り先を決める %>
-    <% back_path =
+  <%# ← 戻り先 %>
+  <% back_path =
     case @reportable
     when Recipe  then recipe_path(@reportable)
     when Comment then recipe_path(@reportable.recipe)
@@ -14,26 +14,42 @@
     end
   %>
 
-  <%= form_with model: @report, url: reports_path(
-        reportable_type: @reportable.class.name,
-        reportable_id: @reportable.id
-      ), class: "needs-validation" do |f| %>
+
+  <%= form_with model: @report,
+        url: reports_path(reportable_type: @reportable.class.name, reportable_id: @reportable.id),
+        class: "needs-validation",
+        local: true do |f| %>
+
+    <%# ★ エラー表示 %>
+    <% if @report.errors.any? %>
+      <div class="alert alert-danger">
+        <strong><%= t("errors.messages.not_saved", count: @report.errors.count, resource: Report.model_name.human, default: "入力エラーがあります") %></strong>
+        <ul class="mb-0">
+          <% @report.errors.full_messages.each do |msg| %>
+            <li><%= msg %></li>
+          <% end %>
+        </ul>
+      </div>
+    <% end %>
 
     <div class="mb-3">
       <%= f.label :reason, t("activerecord.attributes.report.reason"), class: "form-label" %>
-      <%= f.select :reason, Report.reasons.keys.map { |k|
-            [t("activerecord.attributes.report.reasons.#{k}"), k]
-          }, {}, class: "form-select", required: true, aria: { describedby: "reasonHelp" } %>
-      <div id="reasonHelp" class="form-text"><%= t("reports.reason_help") %></div>
+      <%= f.select :reason,
+          Report.reasons.keys.map { |k| [t("activerecord.attributes.report.reasons.#{k}", default: k.humanize), k] },
+          {},
+          class: "form-select",
+          required: true,
+          aria: { describedby: "reasonHelp" } %>
+      <div id="reasonHelp" class="form-text"><%= t("reports.reason_help", default: "最も近い理由を選択してください") %></div>
     </div>
 
     <div class="mb-3">
       <%= f.label :description, t("activerecord.attributes.report.description"), class: "form-label" %>
       <%= f.text_area :description, rows: 5, class: "form-control",
-            placeholder: t("reports.description_placeholder"), required: true %>
+            placeholder: t("reports.description_placeholder", default: "具体的な問題点を記入してください（10文字以上）"),
+            required: true %>
     </div>
-
-    <%= f.submit t("reports.submit"), class: "btn btn-danger" %>
-    <%= link_to t("common.cancel"), back_path,   class: "btn btn-secondary" %>
+    <%= f.submit t("reports.submit", default: "通報する"), class: "btn btn-danger" %>
+    <%= link_to t("common.cancel", default: "キャンセル"), back_path, class: "btn btn-secondary" %>
   <% end %>
 </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -121,4 +121,16 @@
       </div>
     <% end %>
   </div>
+
+    <!-- 通報ボタン（ユーザー通報） -->
+    <% if user_signed_in? && current_user != @user %>
+      <% unless @user.reported_by?(current_user) %>
+        <%= link_to t("reports.report_this_user", default: "このユーザーを通報"),
+            new_report_path(user_id: @user.id),
+            class: "btn btn-outline-danger btn-sm",
+            "aria-label": t("reports.aria_report_user", default: "Report this user") %>
+      <% else %>
+        <span class="text-muted small"><%= t("reports.already_reported", default: "通報済み") %></span>
+      <% end %>
+    <% end %>
 </div>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,28 @@
+ja:
+  reports:
+    created: "通報を受け付けました"
+    create_failed: "通報に失敗しました。入力内容をご確認ください"
+    already_reported: "この対象は既に通報済みです"
+    report_this: "通報する"
+    reason_help: "最も近い理由を選択してください"
+    description_placeholder: "具体的な問題点を記入してください"
+    submit: "通報する"
+    aria_report_recipe: "このレシピを通報する"
+  activerecord:
+    attributes:
+      report:
+        reason: "通報理由"
+        description: "詳細説明"
+        reasons:
+          spam: "スパム"
+          inappropriate: "不適切な表現"
+          copyright: "著作権侵害"
+          other: "その他"
+    errors:
+      models:
+        report:
+          attributes:
+            reporter_id:
+              already_reported: "同じ対象は一度しか通報できません"
+  common:
+    cancel: "キャンセル"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,6 @@ Rails.application.routes.draw do
 
   # トップページ
   root 'recipes#index'
-
   # レシピ
   resources :recipes do
     collection do
@@ -15,15 +14,13 @@ Rails.application.routes.draw do
     resources :comments, only: [:create, :destroy]
     resources :ratings,  only: [:create]
   end
-
   # ユーザー
   resources :users, only: [:show, :edit, :update] do
     member { get :favorites }
     resource :follow, only: [:create, :destroy]
   end
-
   # レポート（公開側）
-  resources :reports, only: [:create]
+  resources :reports, only: [:new, :create]
   get 'reports/recipes/:recipe_id/new',   to: 'reports#new', as: :new_recipe_report
   get 'reports/comments/:comment_id/new', to: 'reports#new', as: :new_comment_report
   get 'reports/users/:user_id/new',       to: 'reports#new', as: :new_user_report

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,7 +29,7 @@ Rails.application.routes.draw do
   namespace :admin do
     root 'dashboard#index'
 
-    resources :reports, only: [:index, :show] do
+    resources :reports, only: [:index, :show, :update] do
       member do
         patch :resolve
         patch :dismiss

--- a/db/migrate/20251002115529_add_unique_index_to_reports.rb
+++ b/db/migrate/20251002115529_add_unique_index_to_reports.rb
@@ -1,7 +1,12 @@
 class AddUniqueIndexToReports < ActiveRecord::Migration[7.1]
   def change
-    add_index :reports, [:reporter_id, :reportable_type, :reportable_id],
-      unique: true, name: "idx_reports_uniqueness_on_reporter_and_reportable"
-    add_index :users, :suspended_until  # 管理画面での抽出高速化（任意）
+    # reports のユニークインデックスだけ付けたいならこれでOK
+    add_index :reports,
+              [:reporter_id, :reportable_type, :reportable_id],
+              unique: true,
+              name: "idx_reports_uniqueness_on_reporter_and_reportable"
+
+    # ↓この行が重複原因。既に存在するので **削除** するか、ガードを付ける
+    # add_index :users, :suspended_until
   end
 end

--- a/db/migrate/20251002115529_add_unique_index_to_reports.rb
+++ b/db/migrate/20251002115529_add_unique_index_to_reports.rb
@@ -1,0 +1,7 @@
+class AddUniqueIndexToReports < ActiveRecord::Migration[7.1]
+  def change
+    add_index :reports, [:reporter_id, :reportable_type, :reportable_id],
+      unique: true, name: "idx_reports_uniqueness_on_reporter_and_reportable"
+    add_index :users, :suspended_until  # 管理画面での抽出高速化（任意）
+  end
+end

--- a/db/migrate/20251004090345_set_default_and_not_null_on_reports_status.rb
+++ b/db/migrate/20251004090345_set_default_and_not_null_on_reports_status.rb
@@ -1,0 +1,17 @@
+class SetDefaultAndNotNullOnReportsStatus < ActiveRecord::Migration[7.1]
+  def up
+    # 1) 既存NULLを埋める
+    execute "UPDATE reports SET status = 0 WHERE status IS NULL"
+
+    # 2) 既定値を0（pending）に
+    change_column_default :reports, :status, from: nil, to: 0
+
+    # 3) NOT NULL 制約
+    change_column_null :reports, :status, false
+  end
+
+  def down
+    change_column_null :reports, :status, true
+    change_column_default :reports, :status, from: 0, to: nil
+  end
+end

--- a/db/migrate/20251004205552_backfill_report_status_and_default.rb
+++ b/db/migrate/20251004205552_backfill_report_status_and_default.rb
@@ -1,0 +1,13 @@
+class BackfillReportStatusAndDefault < ActiveRecord::Migration[7.1]
+  def up
+    # enumを整数で使う前提
+    execute "UPDATE reports SET status = 0 WHERE status IS NULL"
+    change_column_default :reports, :status, 0
+    change_column_null :reports, :status, false
+  end
+
+  def down
+    change_column_null :reports, :status, true
+    change_column_default :reports, :status, nil
+  end
+end

--- a/db/migrate/20251005114020_set_default_for_reports_reason.rb
+++ b/db/migrate/20251005114020_set_default_for_reports_reason.rb
@@ -1,0 +1,10 @@
+class SetDefaultForReportsReason < ActiveRecord::Migration[7.1]
+  def up
+    execute "UPDATE reports SET reason = 3 WHERE reason IS NULL"  # :other
+    change_column_default :reports, :reason, 3
+  end
+
+  def down
+    change_column_default :reports, :reason, nil
+  end
+end

--- a/db/migrate/20251005194011_backfill_reason_on_reports.rb
+++ b/db/migrate/20251005194011_backfill_reason_on_reports.rb
@@ -1,0 +1,13 @@
+class BackfillReasonOnReports < ActiveRecord::Migration[7.1]
+  def up
+    # enum reason: { spam: 0, inappropriate: 1, copyright: 2, other: 3 }
+    execute "UPDATE reports SET reason = 3 WHERE reason IS NULL"
+    change_column_default :reports, :reason, 3
+    change_column_null :reports, :reason, false
+  end
+
+  def down
+    change_column_null :reports, :reason, true
+    change_column_default :reports, :reason, nil
+  end
+end

--- a/db/migrate/20251006084031_convert_reports_reason_text_to_integer.rb
+++ b/db/migrate/20251006084031_convert_reports_reason_text_to_integer.rb
@@ -1,0 +1,35 @@
+class ConvertReportsReasonTextToInteger < ActiveRecord::Migration[7.1]
+  def up
+    # 0) 既定値を外す（これが今回のエラー原因）
+    execute "ALTER TABLE reports ALTER COLUMN reason DROP DEFAULT"
+
+    # 1) 値を整数文字に正規化
+    execute <<~SQL
+      UPDATE reports SET reason = '0' WHERE reason IN ('spam','0');
+      UPDATE reports SET reason = '1' WHERE reason IN ('inappropriate','1');
+      UPDATE reports SET reason = '2' WHERE reason IN ('copyright','2');
+      UPDATE reports SET reason = '3' WHERE reason IS NULL OR reason = '' OR reason IN ('other','3');
+    SQL
+
+    # 2) 型を integer に変更
+    change_column :reports, :reason, :integer, using: "reason::integer"
+
+    # 3) 必要なら既定値とNOT NULLを設定（不要なら消してOK）
+    change_column_default :reports, :reason, 3
+    change_column_null    :reports, :reason, false
+  end
+
+  def down
+    # 既定値は一旦外す
+    change_column_default :reports, :reason, nil
+    # 型をstringへ戻す
+    change_column :reports, :reason, :string
+    # 整数→文字列へ戻す（念のためNULLや空もotherへ）
+    execute <<~SQL
+      UPDATE reports SET reason = 'spam'          WHERE reason = '0';
+      UPDATE reports SET reason = 'inappropriate' WHERE reason = '1';
+      UPDATE reports SET reason = 'copyright'     WHERE reason = '2';
+      UPDATE reports SET reason = 'other'         WHERE reason IS NULL OR reason = '' OR reason = '3';
+    SQL
+  end
+end

--- a/db/migrate/20251006132832_convert_reports_status_text_to_integer.rb
+++ b/db/migrate/20251006132832_convert_reports_status_text_to_integer.rb
@@ -1,0 +1,35 @@
+class ConvertReportsStatusTextToInteger < ActiveRecord::Migration[7.1]
+  def up
+    # 0) 文字列の既定値が付いていると型変換で失敗するので先に外す
+    execute "ALTER TABLE reports ALTER COLUMN status DROP DEFAULT"
+
+    # 1) 既存の文字列/NULLを整数文字に正規化（enum: pending:0, investigating:1, resolved:2, dismissed:3）
+    execute <<~SQL
+      UPDATE reports SET status = '0' WHERE status IN ('pending','0');
+      UPDATE reports SET status = '1' WHERE status IN ('investigating','1');
+      UPDATE reports SET status = '2' WHERE status IN ('resolved','2');
+      UPDATE reports SET status = '3' WHERE status IN ('dismissed','3');
+      UPDATE reports SET status = '0' WHERE status IS NULL OR status = '';
+    SQL
+
+    # 2) text → integer（USING で明示キャスト）
+    change_column :reports, :status, :integer, using: "status::integer"
+
+    # 3) 既定値＆NOT NULL（再発防止）
+    change_column_default :reports, :status, 0
+    change_column_null    :reports, :status, false
+
+    # 4) 任意：範囲制約（0..3 のみ許可）
+    add_check_constraint :reports, "status IN (0,1,2,3)", name: "reports_status_enum"
+  end
+
+  def down
+    # 逆変換（必要最小限）
+    remove_check_constraint :reports, name: "reports_status_enum" rescue nil
+    change_column_default :reports, :status, nil
+    change_column_null    :reports, :status, true
+    change_column :reports, :status, :string
+  end
+end
+
+

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_09_26_065752) do
+ActiveRecord::Schema[7.1].define(version: 2025_10_02_115529) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -151,6 +151,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_09_26_065752) do
     t.index ["admin_user_id"], name: "index_reports_on_admin_user_id"
     t.index ["created_at"], name: "index_reports_on_created_at"
     t.index ["reportable_type", "reportable_id"], name: "index_reports_on_reportable"
+    t.index ["reporter_id", "reportable_type", "reportable_id"], name: "idx_reports_uniqueness_on_reporter_and_reportable", unique: true
     t.index ["reporter_id", "reportable_type", "reportable_id"], name: "index_reports_on_reporter_and_reportable", unique: true
     t.index ["reporter_id"], name: "index_reports_on_reporter_id"
     t.index ["status"], name: "index_reports_on_status"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_10_02_115529) do
+ActiveRecord::Schema[7.1].define(version: 2025_10_04_090345) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -142,7 +142,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_10_02_115529) do
     t.bigint "reportable_id", null: false, comment: "報告対象"
     t.text "reason", null: false, comment: "報告理由"
     t.text "description", comment: "詳細説明"
-    t.string "status", default: "pending", null: false, comment: "処理状況"
+    t.string "status", default: "0", null: false, comment: "処理状況"
     t.bigint "admin_user_id", comment: "対応した管理者"
     t.text "admin_response", comment: "管理者からの回答"
     t.datetime "resolved_at", comment: "解決日時"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_10_06_084031) do
+ActiveRecord::Schema[7.1].define(version: 2025_10_06_132832) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -142,7 +142,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_10_06_084031) do
     t.bigint "reportable_id", null: false, comment: "報告対象"
     t.integer "reason", default: 3, null: false, comment: "報告理由"
     t.text "description", comment: "詳細説明"
-    t.string "status", default: "0", null: false, comment: "処理状況"
+    t.integer "status", default: 0, null: false, comment: "処理状況"
     t.bigint "admin_user_id", comment: "対応した管理者"
     t.text "admin_response", comment: "管理者からの回答"
     t.datetime "resolved_at", comment: "解決日時"
@@ -155,6 +155,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_10_06_084031) do
     t.index ["reporter_id", "reportable_type", "reportable_id"], name: "index_reports_on_reporter_and_reportable", unique: true
     t.index ["reporter_id"], name: "index_reports_on_reporter_id"
     t.index ["status"], name: "index_reports_on_status"
+    t.check_constraint "status = ANY (ARRAY[0, 1, 2, 3])", name: "reports_status_enum"
   end
 
   create_table "steps", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_10_04_090345) do
+ActiveRecord::Schema[7.1].define(version: 2025_10_05_114020) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -140,7 +140,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_10_04_090345) do
     t.bigint "reporter_id", null: false, comment: "報告したユーザー"
     t.string "reportable_type", null: false
     t.bigint "reportable_id", null: false, comment: "報告対象"
-    t.text "reason", null: false, comment: "報告理由"
+    t.text "reason", default: "3", null: false, comment: "報告理由"
     t.text "description", comment: "詳細説明"
     t.string "status", default: "0", null: false, comment: "処理状況"
     t.bigint "admin_user_id", comment: "対応した管理者"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_10_05_114020) do
+ActiveRecord::Schema[7.1].define(version: 2025_10_06_084031) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -140,7 +140,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_10_05_114020) do
     t.bigint "reporter_id", null: false, comment: "報告したユーザー"
     t.string "reportable_type", null: false
     t.bigint "reportable_id", null: false, comment: "報告対象"
-    t.text "reason", default: "3", null: false, comment: "報告理由"
+    t.integer "reason", default: 3, null: false, comment: "報告理由"
     t.text "description", comment: "詳細説明"
     t.string "status", default: "0", null: false, comment: "処理状況"
     t.bigint "admin_user_id", comment: "対応した管理者"


### PR DESCRIPTION
① 通報ができないエラー
原因
User モデルの関連名が誤っており、has_many :reports が競合していた。
create アクションで同一ユーザーによる重複通報を防ぐ処理がなかった。
修正
関連を has_many :submitted_reports にリネーム。
ReportsController#create に重複チェックを追加。

② レポート送信後にレシピ管理へ遷移できない
原因
report.admin_user が nil のまま .display_name を呼び出してエラー。
レポート対象削除時の reportable 参照でnil落ち。
修正
安全ナビゲーション（&.）とデフォルト文字列でnil安全化。
一覧取得時に includes(:reporter, :admin_user, :reportable) を追加。

③ レポートのアクションボタンが動作しない
原因
ビュー内の link_to ... method: :patch, params: 形式で status が送られていなかった。
enum reason とDBの型(text)が不一致。
修正
link_to admin_report_path(@report, report: { status: '...' }), data: { turbo_method: :patch } に統一。
DBの reason を integer 型に変更して enum と整合。

④ ステータスを「解決済み」に変更できない
原因
params 不備で report[status] が届かず、バリデーション失敗。
description の長さ制限や reason のnilで update が止まっていた。
修正
update 内で status_param を安全に受け取る処理を追加。
バリデーションを実運用向けに緩和（更新時のみチェック）。
reason の既存NULLを other(3) に埋め直し。

⑤ ステータス表示（HTML）が反映されない
原因
DBの status が文字列のままで enum 判定が不正。
Turboのキャッシュで古いHTMLが再利用されていた。
修正
status カラムを integer に統一。
<meta name="turbo-cache-control" content="no-cache"> を追加し、最新HTMLを反映。