### PR TITLE
管理画面のレシピ更新処理テスト追加とコントローラー修正

### DIFF
--- a/app/controllers/admin/recipes_controller.rb
+++ b/app/controllers/admin/recipes_controller.rb
@@ -1,5 +1,5 @@
 class Admin::RecipesController < Admin::BaseController
-  before_action :set_recipe, only: [:show, :destroy, :hide, :unhide] 
+  before_action :set_recipe, only: [:show, :edit, :update, :destroy, :hide, :unhide]
 
   def index
     # フィルタ（検索・並び順・件数）
@@ -55,6 +55,17 @@ class Admin::RecipesController < Admin::BaseController
   def show
    # いったん公開側の詳細にリダイレクト（管理用のshowを作るまでの暫定）
    redirect_to recipe_path(@recipe)
+  end
+
+  def edit
+  end
+  
+  def update
+    if @recipe.update(recipe_params)
+      redirect_to admin_recipe_path(@recipe), notice: 'レシピを更新しました'
+    else
+      render :edit, status: :unprocessable_entity
+    end
   end
 
   def destroy
@@ -160,4 +171,19 @@ class Admin::RecipesController < Admin::BaseController
     stats[:avg_cooking_time] = Recipe.column_names.include?('cooking_time') ? Recipe.average(:cooking_time).to_i : nil
     stats
   end
+
+  def recipe_params
+    params.require(:recipe).permit(
+      :title,
+      :description,
+      :cooking_time,
+      :servings,
+      :hidden,
+      :image,
+      category_ids: [],
+      ingredients_attributes: [:id, :name, :amount, :order_number, :_destroy],
+      steps_attributes: [:id, :instruction, :step_number, :_destroy]
+    )
+  end
+  
 end

--- a/app/controllers/admin/recipes_controller.rb
+++ b/app/controllers/admin/recipes_controller.rb
@@ -64,7 +64,7 @@ class Admin::RecipesController < Admin::BaseController
     if @recipe.update(recipe_params)
       redirect_to admin_recipe_path(@recipe), notice: 'レシピを更新しました'
     else
-      render :edit, status: :unprocessable_entity
+      render :edit, status: :unprocessable_content
     end
   end
 

--- a/app/views/admin/recipes/edit.html.erb
+++ b/app/views/admin/recipes/edit.html.erb
@@ -1,0 +1,11 @@
+<h1>レシピ編集</h1>
+
+<% if @recipe.errors.any? %>
+  <div class="alert alert-danger">
+    <ul>
+      <% @recipe.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>

--- a/app/views/admin/recipes/edit.html.erb
+++ b/app/views/admin/recipes/edit.html.erb
@@ -9,3 +9,34 @@
     </ul>
   </div>
 <% end %>
+
+<%= form_with model: [:admin, @recipe], local: true do |f| %>
+  <div>
+    <%= f.label :title, "タイトル" %><br>
+    <%= f.text_field :title %>
+  </div>
+
+  <div>
+    <%= f.label :description, "説明" %><br>
+    <%= f.text_area :description %>
+  </div>
+
+  <div>
+    <%= f.label :cooking_time, "調理時間" %><br>
+    <%= f.number_field :cooking_time %>
+  </div>
+
+  <div>
+    <%= f.label :servings, "人数" %><br>
+    <%= f.number_field :servings %>
+  </div>
+
+  <div>
+    <%= f.label :hidden, "非公開" %>
+    <%= f.check_box :hidden %>
+  </div>
+
+  <div>
+    <%= f.submit "更新する" %>
+  </div>
+<% end %>

--- a/spec/requests/admin/recipes_update_spec.rb
+++ b/spec/requests/admin/recipes_update_spec.rb
@@ -33,6 +33,32 @@ RSpec.describe "Admin::Recipes 更新系", type: :request do
     end
   end
 
+  shared_examples "一般ユーザーはrootへ" do |verb, path_proc, params = nil|
+    it "302でrootへリダイレクトされ、DBは変更されない" do
+      sign_in create(:user)
+
+      original_attrs = recipe.attributes.slice("title", "description", "cooking_time", "servings", "hidden")
+      original_count = Recipe.count
+
+      if params
+        public_send(verb, instance_exec(&path_proc), params: params)
+      else
+        public_send(verb, instance_exec(&path_proc))
+      end
+
+      expect(response).to have_http_status(:found)
+      expect(response).to redirect_to(root_path)
+
+      if verb == :delete
+        expect(Recipe.count).to eq(original_count)
+      else
+        recipe.reload
+        expect(recipe.attributes.slice("title", "description", "cooking_time", "servings", "hidden"))
+          .to eq(original_attrs)
+      end
+    end
+  end
+
 
 
   

--- a/spec/requests/admin/recipes_update_spec.rb
+++ b/spec/requests/admin/recipes_update_spec.rb
@@ -179,6 +179,19 @@ RSpec.describe "Admin::Recipes 更新系", type: :request do
 
     include_examples "未ログインはログイン画面へ", :patch, -> { unhide_path }
     include_examples "一般ユーザーはrootへ", :patch, -> { unhide_path }
+    context "管理者" do
+      before { sign_in admin }
 
+      it "レシピを公開に戻せる" do
+        patch unhide_path
+
+        expect(response).to have_http_status(:found)
+        expect(response).to redirect_to(admin_recipes_path)
+
+        recipe.reload
+        expect(recipe.hidden).to eq(false)
+      end
+    end
+  end
   
 end

--- a/spec/requests/admin/recipes_update_spec.rb
+++ b/spec/requests/admin/recipes_update_spec.rb
@@ -172,5 +172,13 @@ RSpec.describe "Admin::Recipes 更新系", type: :request do
     end
   end
 
+  describe "PATCH /admin/recipes/:id/unhide" do
+    before do
+      recipe.update!(hidden: true)
+    end
+
+    include_examples "未ログインはログイン画面へ", :patch, -> { unhide_path }
+    include_examples "一般ユーザーはrootへ", :patch, -> { unhide_path }
+
   
 end

--- a/spec/requests/admin/recipes_update_spec.rb
+++ b/spec/requests/admin/recipes_update_spec.rb
@@ -10,7 +10,30 @@ RSpec.describe "Admin::Recipes 更新系", type: :request do
   let(:unhide_path)  { unhide_admin_recipe_path(recipe) }
 
   shared_examples "未ログインはログイン画面へ" do |verb, path_proc, params = nil|
+    it "302でログイン画面へリダイレクトされ、DBは変更されない" do
+      original_attrs = recipe.attributes.slice("title", "description", "cooking_time", "servings", "hidden")
+      original_count = Recipe.count
 
+      if params
+        public_send(verb, instance_exec(&path_proc), params: params)
+      else
+        public_send(verb, instance_exec(&path_proc))
+      end
 
+      expect(response).to have_http_status(:found)
+      expect(response).to redirect_to(new_user_session_path)
 
+      if verb == :delete
+        expect(Recipe.count).to eq(original_count)
+      else
+        recipe.reload
+        expect(recipe.attributes.slice("title", "description", "cooking_time", "servings", "hidden"))
+          .to eq(original_attrs)
+      end
+    end
   end
+
+
+
+  
+end

--- a/spec/requests/admin/recipes_update_spec.rb
+++ b/spec/requests/admin/recipes_update_spec.rb
@@ -116,6 +116,40 @@ RSpec.describe "Admin::Recipes 更新系", type: :request do
         expect(recipe.attributes.slice("title", "description", "cooking_time", "servings"))
           .to eq(original_attrs)
       end
+      
+      it "hidden属性も更新できる" do
+        expect(recipe.hidden).to eq(false)
+
+        patch update_path, params: { recipe: { hidden: true } }
+
+        expect(response).to have_http_status(:found)
+        expect(response).to redirect_to(admin_recipe_path(recipe))
+
+        recipe.reload
+        expect(recipe.hidden).to eq(true)
+      end
+    end
+  end
+
+  describe "DELETE /admin/recipes/:id" do
+    include_examples "未ログインはログイン画面へ", :delete, -> { destroy_path }
+    include_examples "一般ユーザーはrootへ", :delete, -> { destroy_path }
+
+    context "管理者" do
+      before { sign_in admin }
+
+      it "レシピを削除できる" do
+        recipe
+
+        expect do
+          delete destroy_path
+        end.to change(Recipe, :count).by(-1)
+
+        expect(response).to have_http_status(:found)
+        expect(response).to redirect_to(admin_recipes_path)
+      end
+    end
+  end
 
 
 

--- a/spec/requests/admin/recipes_update_spec.rb
+++ b/spec/requests/admin/recipes_update_spec.rb
@@ -105,6 +105,18 @@ RSpec.describe "Admin::Recipes 更新系", type: :request do
         expect(recipe.servings).to eq(4)
       end
 
+      it "無効なパラメータでは更新されず422を返す" do
+        original_attrs = recipe.attributes.slice("title", "description", "cooking_time", "servings")
+
+        patch update_path, params: invalid_params
+
+        expect(response).to have_http_status(:unprocessable_entity)
+
+        recipe.reload
+        expect(recipe.attributes.slice("title", "description", "cooking_time", "servings"))
+          .to eq(original_attrs)
+      end
+
 
 
   

--- a/spec/requests/admin/recipes_update_spec.rb
+++ b/spec/requests/admin/recipes_update_spec.rb
@@ -1,0 +1,16 @@
+require "rails_helper"
+
+RSpec.describe "Admin::Recipes 更新系", type: :request do
+  let(:admin)  { create(:user, :admin) }
+  let(:recipe) { create(:recipe) }
+
+  let(:update_path)  { admin_recipe_path(recipe) }
+  let(:destroy_path) { admin_recipe_path(recipe) }
+  let(:hide_path)    { hide_admin_recipe_path(recipe) }
+  let(:unhide_path)  { unhide_admin_recipe_path(recipe) }
+
+  shared_examples "未ログインはログイン画面へ" do |verb, path_proc, params = nil|
+
+
+
+  end

--- a/spec/requests/admin/recipes_update_spec.rb
+++ b/spec/requests/admin/recipes_update_spec.rb
@@ -59,6 +59,52 @@ RSpec.describe "Admin::Recipes 更新系", type: :request do
     end
   end
 
+  describe "PATCH /admin/recipes/:id" do
+    let(:valid_params) do
+      {
+        recipe: {
+          title: "更新後タイトル",
+          description: "更新後の説明文です",
+          cooking_time: 25,
+          servings: 4
+        }
+      }
+    end
+
+    let(:invalid_params) do
+      {
+        recipe: {
+          title: "",
+          description: "更新後の説明文です",
+          cooking_time: 25,
+          servings: 4
+        }
+      }
+    end
+
+    include_examples "未ログインはログイン画面へ", :patch, -> { update_path }, {
+      recipe: { title: "変更タイトル" }
+    }
+    include_examples "一般ユーザーはrootへ", :patch, -> { update_path }, {
+      recipe: { title: "変更タイトル" }
+    }
+
+    context "管理者" do
+      before { sign_in admin }
+
+      it "有効なパラメータで更新できる" do
+        patch update_path, params: valid_params
+
+        expect(response).to have_http_status(:found)
+        expect(response).to redirect_to(admin_recipe_path(recipe))
+
+        recipe.reload
+        expect(recipe.title).to eq("更新後タイトル")
+        expect(recipe.description).to eq("更新後の説明文です")
+        expect(recipe.cooking_time).to eq(25)
+        expect(recipe.servings).to eq(4)
+      end
+
 
 
   

--- a/spec/requests/admin/recipes_update_spec.rb
+++ b/spec/requests/admin/recipes_update_spec.rb
@@ -151,7 +151,26 @@ RSpec.describe "Admin::Recipes 更新系", type: :request do
     end
   end
 
+  describe "PATCH /admin/recipes/:id/hide" do
+    include_examples "未ログインはログイン画面へ", :patch, -> { hide_path }
+    include_examples "一般ユーザーはrootへ", :patch, -> { hide_path }
 
+    context "管理者" do
+      before { sign_in admin }
+
+      it "レシピを非公開にできる" do
+        expect(recipe.hidden).to eq(false)
+
+        patch hide_path
+
+        expect(response).to have_http_status(:found)
+        expect(response).to redirect_to(admin_recipes_path)
+
+        recipe.reload
+        expect(recipe.hidden).to eq(true)
+      end
+    end
+  end
 
   
 end

--- a/spec/requests/admin/recipes_update_spec.rb
+++ b/spec/requests/admin/recipes_update_spec.rb
@@ -110,7 +110,7 @@ RSpec.describe "Admin::Recipes 更新系", type: :request do
 
         patch update_path, params: invalid_params
 
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
 
         recipe.reload
         expect(recipe.attributes.slice("title", "description", "cooking_time", "servings"))


### PR DESCRIPTION
管理画面のレシピ更新処理のテストを追加
未ログイン時はログイン画面へ移動することを確認
一般ユーザーはトップページへ戻されることを確認
管理者はレシピを更新できることを確認
無効な値では更新されず、エラーになることを確認
hidden属性も更新できることを確認
管理者はレシピを削除できることを確認
管理者はレシピを非公開にできることを確認
管理者は非公開のレシピを再公開できることを確認
更新失敗時に編集画面を表示できるよう修正
コントローラーの422ステータス表記を新しい書き方に修正