### PR TITLE
管理者用レシピ一覧画面のリクエストテストを追加

### DIFF
--- a/app/views/admin/recipes/index.html.erb
+++ b/app/views/admin/recipes/index.html.erb
@@ -127,15 +127,17 @@
       <!-- 表示件数 -->
       <div class="col-md-2">
         <%= form.label :per_page, "表示件数", class: "form-label" %>
-        <%= form.select :per_page, 
+        <%= form.select :per_page,
             options_for_select([
-              ['12件', '12'],
-              ['24件', '24'],
-              ['48件', '48']
-            ], @filter_params[:per_page] || '12'), 
-            {}, 
+              ['20件', '20'],
+              ['50件', '50'],
+              ['100件', '100']
+            ], @filter_params[:per_page] || '20'),
+            {},
             { class: "form-select" } %>
       </div>
+
+
     <% end %>
   </div>
 </div>

--- a/spec/requests/admin/recipes_index_spec.rb
+++ b/spec/requests/admin/recipes_index_spec.rb
@@ -195,5 +195,11 @@ RSpec.describe "Admin::Recipes 一覧系", type: :request do
           expect(response).to have_http_status(:ok)
           expect(response.body.scan(/一覧テストレシピ\d+/).count).to eq 20
         end
+        it "per_page=50の場合、25件表示される" do
+          get admin_recipes_path, params: { per_page: 50 }
+
+          expect(response).to have_http_status(:ok)
+          expect(response.body.scan(/一覧テストレシピ\d+/).count).to eq 25
+        end
 
 end

--- a/spec/requests/admin/recipes_index_spec.rb
+++ b/spec/requests/admin/recipes_index_spec.rb
@@ -208,5 +208,13 @@ RSpec.describe "Admin::Recipes 一覧系", type: :request do
           expect(response).to have_http_status(:ok)
           expect(response.body.scan(/一覧テストレシピ\d+/).count).to eq 25
         end
+        it "不正なper_pageの場合、20件にフォールバックする" do
+          get admin_recipes_path, params: { per_page: 999 }
 
+          expect(response).to have_http_status(:ok)
+          expect(response.body.scan(/一覧テストレシピ\d+/).count).to eq 20
+        end
+      end
+    end
+  end
 end

--- a/spec/requests/admin/recipes_index_spec.rb
+++ b/spec/requests/admin/recipes_index_spec.rb
@@ -114,4 +114,12 @@ RSpec.describe "Admin::Recipes 一覧系", type: :request do
           expect(response.body.index("新しいレシピ")).to be < response.body.index("中間のレシピ")
           expect(response.body.index("中間のレシピ")).to be < response.body.index("古いレシピ")
         end
+        it "created_ascでは古い順に表示される" do
+          get admin_recipes_path, params: { sort: "created_asc" }
+
+          expect(response).to have_http_status(:ok)
+
+          expect(response.body.index("古いレシピ")).to be < response.body.index("中間のレシピ")
+          expect(response.body.index("中間のレシピ")).to be < response.body.index("新しいレシピ")
+        end
 end

--- a/spec/requests/admin/recipes_index_spec.rb
+++ b/spec/requests/admin/recipes_index_spec.rb
@@ -65,4 +65,45 @@ RSpec.describe "Admin::Recipes 一覧系", type: :request do
             user: user
           )
         end
+
+        it "タイトルまたは説明文に一致したレシピだけ表示される" do
+          get admin_recipes_path, params: { search: "カレー" }
+
+          expect(response).to have_http_status(:ok)
+          expect(response.body).to include("和風カレー")
+          expect(response.body).to include("別の料理")
+          expect(response.body).not_to include("オムライス")
+        end
+      end
+
+      describe "並び順" do
+        let!(:old_recipe) do
+          create(
+            :recipe,
+            title: "古いレシピ",
+            created_at: 3.days.ago,
+            cooking_time: 30,
+            user: user
+          )
+        end
+
+        let!(:middle_recipe) do
+          create(
+            :recipe,
+            title: "中間のレシピ",
+            created_at: 2.days.ago,
+            cooking_time: 20,
+            user: user
+          )
+        end
+
+        let!(:new_recipe) do
+          create(
+            :recipe,
+            title: "新しいレシピ",
+            created_at: 1.day.ago,
+            cooking_time: 10,
+            user: user
+          )
+        end
 end

--- a/spec/requests/admin/recipes_index_spec.rb
+++ b/spec/requests/admin/recipes_index_spec.rb
@@ -4,4 +4,26 @@ RSpec.describe "Admin::Recipes 一覧系", type: :request do
   let(:admin) { create(:user, :admin) }
   let(:user)  { create(:user) }
 
+  describe "GET /admin/recipes" do
+    context "未ログイン" do
+      it "ログイン画面へリダイレクトされる" do
+        get admin_recipes_path
+
+        expect(response).to have_http_status(:found)
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+    context "一般ユーザー" do
+      before do
+        sign_in user
+      end
+
+      it "rootへリダイレクトされる" do
+        get admin_recipes_path
+
+        expect(response).to have_http_status(:found)
+        expect(response).to redirect_to(root_path)
+      end
+    end
+
 end

--- a/spec/requests/admin/recipes_index_spec.rb
+++ b/spec/requests/admin/recipes_index_spec.rb
@@ -26,4 +26,43 @@ RSpec.describe "Admin::Recipes 一覧系", type: :request do
       end
     end
 
+    context "管理者" do
+      before do
+        sign_in admin
+      end
+
+      it "200 OKでレシピ一覧を表示できる" do
+        get admin_recipes_path
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("レシピ一覧")
+      end
+
+      describe "検索" do
+        let!(:matched_by_title) do
+          create(
+            :recipe,
+            title: "和風カレー",
+            description: "普通の説明文です。",
+            user: user
+          )
+        end
+
+        let!(:matched_by_description) do
+          create(
+            :recipe,
+            title: "別の料理",
+            description: "カレー粉を使ったレシピです。",
+            user: user
+          )
+        end
+
+        let!(:not_matched) do
+          create(
+            :recipe,
+            title: "オムライス",
+            description: "卵を使ったレシピです。",
+            user: user
+          )
+        end
 end

--- a/spec/requests/admin/recipes_index_spec.rb
+++ b/spec/requests/admin/recipes_index_spec.rb
@@ -1,0 +1,7 @@
+require "rails_helper"
+
+RSpec.describe "Admin::Recipes 一覧系", type: :request do
+  let(:admin) { create(:user, :admin) }
+  let(:user)  { create(:user) }
+
+end

--- a/spec/requests/admin/recipes_index_spec.rb
+++ b/spec/requests/admin/recipes_index_spec.rb
@@ -167,4 +167,26 @@ RSpec.describe "Admin::Recipes 一覧系", type: :request do
           create(:favorite, recipe: normal_recipe, user: create(:user))
         end
 
+        it "popularではお気に入り数が多い順に表示される" do
+          get admin_recipes_path, params: { sort: "popular" }
+
+          expect(response).to have_http_status(:ok)
+
+          expect(response.body.index("人気レシピ")).to be < response.body.index("普通のレシピ")
+          expect(response.body.index("普通のレシピ")).to be < response.body.index("少ないレシピ")
+        end
+      end
+
+      describe "表示件数" do
+        before do
+          25.times do |i|
+            create(
+              :recipe,
+              title: "一覧テストレシピ#{i + 1}",
+              created_at: i.minutes.ago,
+              user: user
+            )
+          end
+        end
+
 end

--- a/spec/requests/admin/recipes_index_spec.rb
+++ b/spec/requests/admin/recipes_index_spec.rb
@@ -131,5 +131,40 @@ RSpec.describe "Admin::Recipes 一覧系", type: :request do
           expect(response.body.index("中間のレシピ")).to be < response.body.index("古いレシピ")
         end
       end
+      describe "人気順" do
+        let!(:popular_recipe) do
+          create(
+            :recipe,
+            title: "人気レシピ",
+            created_at: 3.days.ago,
+            user: user
+          )
+        end
+
+        let!(:normal_recipe) do
+          create(
+            :recipe,
+            title: "普通のレシピ",
+            created_at: 2.days.ago,
+            user: user
+          )
+        end
+
+        let!(:low_recipe) do
+          create(
+            :recipe,
+            title: "少ないレシピ",
+            created_at: 1.day.ago,
+            user: user
+          )
+        end
+
+        before do
+          3.times do
+            create(:favorite, recipe: popular_recipe, user: create(:user))
+          end
+
+          create(:favorite, recipe: normal_recipe, user: create(:user))
+        end
 
 end

--- a/spec/requests/admin/recipes_index_spec.rb
+++ b/spec/requests/admin/recipes_index_spec.rb
@@ -189,4 +189,11 @@ RSpec.describe "Admin::Recipes 一覧系", type: :request do
           end
         end
 
+        it "per_page=20の場合、20件表示される" do
+          get admin_recipes_path, params: { per_page: 20 }
+
+          expect(response).to have_http_status(:ok)
+          expect(response.body.scan(/一覧テストレシピ\d+/).count).to eq 20
+        end
+
 end

--- a/spec/requests/admin/recipes_index_spec.rb
+++ b/spec/requests/admin/recipes_index_spec.rb
@@ -122,4 +122,14 @@ RSpec.describe "Admin::Recipes 一覧系", type: :request do
           expect(response.body.index("古いレシピ")).to be < response.body.index("中間のレシピ")
           expect(response.body.index("中間のレシピ")).to be < response.body.index("新しいレシピ")
         end
+        it "cooking_timeでは調理時間が短い順に表示される" do
+          get admin_recipes_path, params: { sort: "cooking_time" }
+
+          expect(response).to have_http_status(:ok)
+
+          expect(response.body.index("新しいレシピ")).to be < response.body.index("中間のレシピ")
+          expect(response.body.index("中間のレシピ")).to be < response.body.index("古いレシピ")
+        end
+      end
+
 end

--- a/spec/requests/admin/recipes_index_spec.rb
+++ b/spec/requests/admin/recipes_index_spec.rb
@@ -201,5 +201,12 @@ RSpec.describe "Admin::Recipes 一覧系", type: :request do
           expect(response).to have_http_status(:ok)
           expect(response.body.scan(/一覧テストレシピ\d+/).count).to eq 25
         end
+        
+        it "per_page=100の場合、25件表示される" do
+          get admin_recipes_path, params: { per_page: 100 }
+
+          expect(response).to have_http_status(:ok)
+          expect(response.body.scan(/一覧テストレシピ\d+/).count).to eq 25
+        end
 
 end

--- a/spec/requests/admin/recipes_index_spec.rb
+++ b/spec/requests/admin/recipes_index_spec.rb
@@ -106,4 +106,12 @@ RSpec.describe "Admin::Recipes 一覧系", type: :request do
             user: user
           )
         end
+        it "created_descでは新しい順に表示される" do
+          get admin_recipes_path, params: { sort: "created_desc" }
+
+          expect(response).to have_http_status(:ok)
+
+          expect(response.body.index("新しいレシピ")).to be < response.body.index("中間のレシピ")
+          expect(response.body.index("中間のレシピ")).to be < response.body.index("古いレシピ")
+        end
 end


### PR DESCRIPTION
## 概要

## 追加したテスト内容

- 未ログインの場合、ログイン画面へリダイレクトされることを確認
- 一般ユーザーの場合、トップページへリダイレクトされることを確認
- 管理者の場合、レシピ一覧画面を表示できることを確認
- キーワード検索で、タイトルまたは説明文に一致するレシピだけ表示されることを確認
- 新しい順・古い順・調理時間順で並び替えできることを確認
- お気に入り数が多い順で並び替えできることを確認
- 表示件数を20件・50件・100件に切り替えられることを確認
- 不正な表示件数の場合、20件に戻ることを確認

## 補足

- UI操作ではなく、HTTPレスポンスを中心に確認しています
- System specは追加せず、Request specとして作成しました
- テストは合格済みです