### PR TITLE
管理者用レシピCSV出力のリクエストテストを追加

### DIFF
--- a/spec/requests/admin/recipes_export_spec.rb
+++ b/spec/requests/admin/recipes_export_spec.rb
@@ -4,15 +4,16 @@ require "csv"
 RSpec.describe "Admin::Recipes CSVエクスポート", type: :request do
   let(:admin) { create(:user, :admin) }
   let(:user)  { create(:user, email: "user@example.com") }
+
   describe "GET /admin/recipes/export" do
     context "未ログイン" do
-      it "ログイン画面へリダイレクトされる" do
+      it "401 Unauthorizedになる" do
         get admin_recipes_export_path(format: :csv)
 
-        expect(response).to have_http_status(:found)
-        expect(response).to redirect_to(new_user_session_path)
+        expect(response).to have_http_status(:unauthorized)
       end
     end
+
     context "一般ユーザー" do
       before do
         sign_in user
@@ -37,6 +38,7 @@ RSpec.describe "Admin::Recipes CSVエクスポート", type: :request do
         expect(response).to have_http_status(:ok)
         expect(response.media_type).to eq("text/csv")
       end
+
       it "CSVにヘッダーが含まれる" do
         get admin_recipes_export_path(format: :csv)
 
@@ -64,35 +66,27 @@ RSpec.describe "Admin::Recipes CSVエクスポート", type: :request do
         expect(row["user_email"]).to eq("user@example.com")
         expect(row["cooking_time"]).to eq("15")
       end
-      let!(:matched_by_description) do
-        create(
-          :recipe,
-          title: "CSV別料理",
-          description: "カレー粉を使ったレシピです。",
-          user: user
-        )
-      end
-      let!(:not_matched) do
-        create(
-          :recipe,
-          title: "CSVオムライス",
-          description: "卵を使ったレシピです。",
-          user: user
-        )
-      end
-      it "searchに一致したレシピだけCSVに出力される" do
-        get admin_recipes_export_path(format: :csv), params: { search: "カレー" }
 
-        expect(response).to have_http_status(:ok)
+      describe "検索" do
+        let!(:matched_by_title) do
+          create(
+            :recipe,
+            title: "CSVカレー",
+            description: "普通の説明文です。",
+            user: user
+          )
+        end
 
-        csv = CSV.parse(response.body, headers: true)
-        titles = csv.map { |row| row["title"] }
+        let!(:matched_by_description) do
+          create(
+            :recipe,
+            title: "CSV別料理",
+            description: "カレー粉を使ったレシピです。",
+            user: user
+          )
+        end
 
-        expect(titles).to include("CSVカレー")
-        expect(titles).to include("CSV別料理")
-        expect(titles).not_to include("CSVオムライス")
-      end
+
     end
   end
-end
 end

--- a/spec/requests/admin/recipes_export_spec.rb
+++ b/spec/requests/admin/recipes_export_spec.rb
@@ -37,7 +37,16 @@ RSpec.describe "Admin::Recipes CSVエクスポート", type: :request do
         expect(response).to have_http_status(:ok)
         expect(response.media_type).to eq("text/csv")
       end
+      it "CSVにヘッダーが含まれる" do
+        get admin_recipes_export_path(format: :csv)
+
+        csv = CSV.parse(response.body, headers: true)
+
+        expect(csv.headers).to eq(
+          %w[id title user_email created_at cooking_time favorites comments]
+        )
+      end
 
 
-      
+
 end

--- a/spec/requests/admin/recipes_export_spec.rb
+++ b/spec/requests/admin/recipes_export_spec.rb
@@ -85,8 +85,28 @@ RSpec.describe "Admin::Recipes CSVエクスポート", type: :request do
             user: user
           )
         end
+        let!(:not_matched) do
+          create(
+            :recipe,
+            title: "CSVオムライス",
+            description: "卵を使ったレシピです。",
+            user: user
+          )
+        end
 
+        it "searchに一致したレシピだけCSVに出力される" do
+          get admin_recipes_export_path(format: :csv), params: { search: "カレー" }
 
+          expect(response).to have_http_status(:ok)
+
+          csv = CSV.parse(response.body, headers: true)
+          titles = csv.map { |row| row["title"] }
+
+          expect(titles).to include("CSVカレー")
+          expect(titles).to include("CSV別料理")
+          expect(titles).not_to include("CSVオムライス")
+        end
+      end
     end
   end
 end

--- a/spec/requests/admin/recipes_export_spec.rb
+++ b/spec/requests/admin/recipes_export_spec.rb
@@ -47,6 +47,22 @@ RSpec.describe "Admin::Recipes CSVエクスポート", type: :request do
         )
       end
 
+      it "CSVにレシピ情報が含まれる" do
+        recipe = create(
+          :recipe,
+          title: "CSV用レシピ",
+          cooking_time: 15,
+          user: user
+        )
 
+        get admin_recipes_export_path(format: :csv)
+
+        csv = CSV.parse(response.body, headers: true)
+        row = csv.find { |r| r["id"].to_i == recipe.id }
+
+        expect(row["title"]).to eq("CSV用レシピ")
+        expect(row["user_email"]).to eq("user@example.com")
+        expect(row["cooking_time"]).to eq("15")
+      end
 
 end

--- a/spec/requests/admin/recipes_export_spec.rb
+++ b/spec/requests/admin/recipes_export_spec.rb
@@ -13,5 +13,17 @@ RSpec.describe "Admin::Recipes CSVエクスポート", type: :request do
         expect(response).to redirect_to(new_user_session_path)
       end
     end
+    context "一般ユーザー" do
+      before do
+        sign_in user
+      end
+
+      it "rootへリダイレクトされる" do
+        get admin_recipes_export_path(format: :csv)
+
+        expect(response).to have_http_status(:found)
+        expect(response).to redirect_to(root_path)
+      end
+    end
 
 end

--- a/spec/requests/admin/recipes_export_spec.rb
+++ b/spec/requests/admin/recipes_export_spec.rb
@@ -26,4 +26,18 @@ RSpec.describe "Admin::Recipes CSVエクスポート", type: :request do
       end
     end
 
+    context "管理者" do
+      before do
+        sign_in admin
+      end
+
+      it "CSVを取得できる" do
+        get admin_recipes_export_path(format: :csv)
+
+        expect(response).to have_http_status(:ok)
+        expect(response.media_type).to eq("text/csv")
+      end
+
+
+      
 end

--- a/spec/requests/admin/recipes_export_spec.rb
+++ b/spec/requests/admin/recipes_export_spec.rb
@@ -80,5 +80,19 @@ RSpec.describe "Admin::Recipes CSVエクスポート", type: :request do
           user: user
         )
       end
+      it "searchに一致したレシピだけCSVに出力される" do
+        get admin_recipes_export_path(format: :csv), params: { search: "カレー" }
 
+        expect(response).to have_http_status(:ok)
+
+        csv = CSV.parse(response.body, headers: true)
+        titles = csv.map { |row| row["title"] }
+
+        expect(titles).to include("CSVカレー")
+        expect(titles).to include("CSV別料理")
+        expect(titles).not_to include("CSVオムライス")
+      end
+    end
+  end
+end
 end

--- a/spec/requests/admin/recipes_export_spec.rb
+++ b/spec/requests/admin/recipes_export_spec.rb
@@ -64,5 +64,13 @@ RSpec.describe "Admin::Recipes CSVエクスポート", type: :request do
         expect(row["user_email"]).to eq("user@example.com")
         expect(row["cooking_time"]).to eq("15")
       end
+      let!(:matched_by_description) do
+        create(
+          :recipe,
+          title: "CSV別料理",
+          description: "カレー粉を使ったレシピです。",
+          user: user
+        )
+      end4
 
 end

--- a/spec/requests/admin/recipes_export_spec.rb
+++ b/spec/requests/admin/recipes_export_spec.rb
@@ -71,6 +71,14 @@ RSpec.describe "Admin::Recipes CSVエクスポート", type: :request do
           description: "カレー粉を使ったレシピです。",
           user: user
         )
-      end4
+      end
+      let!(:not_matched) do
+        create(
+          :recipe,
+          title: "CSVオムライス",
+          description: "卵を使ったレシピです。",
+          user: user
+        )
+      end
 
 end

--- a/spec/requests/admin/recipes_export_spec.rb
+++ b/spec/requests/admin/recipes_export_spec.rb
@@ -1,0 +1,9 @@
+require "rails_helper"
+require "csv"
+
+RSpec.describe "Admin::Recipes CSVエクスポート", type: :request do
+  let(:admin) { create(:user, :admin) }
+  let(:user)  { create(:user, email: "user@example.com") }
+
+
+    end

--- a/spec/requests/admin/recipes_export_spec.rb
+++ b/spec/requests/admin/recipes_export_spec.rb
@@ -4,6 +4,14 @@ require "csv"
 RSpec.describe "Admin::Recipes CSVエクスポート", type: :request do
   let(:admin) { create(:user, :admin) }
   let(:user)  { create(:user, email: "user@example.com") }
+  describe "GET /admin/recipes/export" do
+    context "未ログイン" do
+      it "ログイン画面へリダイレクトされる" do
+        get admin_recipes_export_path(format: :csv)
 
-
+        expect(response).to have_http_status(:found)
+        expect(response).to redirect_to(new_user_session_path)
+      end
     end
+
+end


### PR DESCRIPTION
## 追加したテスト内容

- 未ログインの場合、401 Unauthorized になることを確認
- 一般ユーザーの場合、トップページへリダイレクトされることを確認
- 管理者の場合、CSVを取得できることを確認
- CSVヘッダーが想定どおり出力されることを確認
- CSVにレシピ名・投稿者メール・調理時間が出力されることを確認
- 検索条件に一致したレシピだけCSVに出力されることを確認