### PR TITLE
管理者用のコメント操作に関するリクエストテストを追加

### DIFF
--- a/app/controllers/admin/comments_controller.rb
+++ b/app/controllers/admin/comments_controller.rb
@@ -1,4 +1,3 @@
-# app/controllers/admin/comments_controller.rb
 class Admin::CommentsController < Admin::BaseController
   before_action :set_admin_breadcrumbs
 

--- a/spec/requests/admin/comments_update_spec.rb
+++ b/spec/requests/admin/comments_update_spec.rb
@@ -122,5 +122,18 @@ RSpec.describe "Admin::Comments 更新系", type: :request do
           expect(response).to have_http_status(:found)
           expect(response).to redirect_to(admin_comments_path)
         end
+        it "対象が未選択の場合、コメントは変更されない" do
+          expect {
+            patch bulk_admin_comments_path, params: {
+              comment_ids: [],
+              bulk_action: "hide"
+            }
+          }.not_to change(Comment, :count)
+  
+          expect(response).to have_http_status(:found)
+          expect(response).to redirect_to(admin_comments_path)
+          expect(comment1.reload.hidden).to be false
+          expect(comment2.reload.hidden).to be false
+        end
 
     end

--- a/spec/requests/admin/comments_update_spec.rb
+++ b/spec/requests/admin/comments_update_spec.rb
@@ -42,6 +42,23 @@ RSpec.describe "Admin::Comments 更新系", type: :request do
         end
       end
     end
+    describe "PATCH /admin/comments/:id/unhide" do
+      let!(:comment) { create(:comment, recipe: recipe, user: user, hidden: true) }
+  
+      context "管理者" do
+        before do
+          sign_in admin
+        end
+  
+        it "コメントを再表示できる" do
+          patch unhide_admin_comment_path(comment)
+  
+          expect(response).to have_http_status(:found)
+          expect(response).to redirect_to(admin_comments_path)
+          expect(comment.reload.hidden).to be false
+        end
+      end
+    end
 
 
     end

--- a/spec/requests/admin/comments_update_spec.rb
+++ b/spec/requests/admin/comments_update_spec.rb
@@ -7,4 +7,12 @@ RSpec.describe "Admin::Comments 更新系", type: :request do
     let!(:comment) { create(:comment, recipe: recipe, user: user, hidden: false) }
 
       end
+      context "未ログイン" do
+        it "ログイン画面へリダイレクトされる" do
+          patch hide_admin_comment_path(comment)
+  
+          expect(response).to have_http_status(:found)
+          expect(response).to redirect_to(new_user_session_path)
+        end
+      end
     end

--- a/spec/requests/admin/comments_update_spec.rb
+++ b/spec/requests/admin/comments_update_spec.rb
@@ -1,3 +1,6 @@
+require "rails_helper"
+
+
 RSpec.describe "Admin::Comments 更新系", type: :request do
   let(:admin) { create(:user, :admin) }
   let(:user)  { create(:user) }
@@ -6,7 +9,6 @@ RSpec.describe "Admin::Comments 更新系", type: :request do
   describe "PATCH /admin/comments/:id/hide" do
     let!(:comment) { create(:comment, recipe: recipe, user: user, hidden: false) }
 
-      end
       context "未ログイン" do
         it "ログイン画面へリダイレクトされる" do
           patch hide_admin_comment_path(comment)
@@ -135,6 +137,17 @@ RSpec.describe "Admin::Comments 更新系", type: :request do
           expect(comment1.reload.hidden).to be false
           expect(comment2.reload.hidden).to be false
         end
-
-
+        it "アクション未選択の場合、コメントは変更されない" do
+          patch bulk_admin_comments_path, params: {
+            comment_ids: [comment1.id, comment2.id],
+            bulk_action: ""
+          }
+  
+          expect(response).to have_http_status(:found)
+          expect(response).to redirect_to(admin_comments_path)
+          expect(comment1.reload.hidden).to be false
+          expect(comment2.reload.hidden).to be false
+        end
+      end
     end
+  end

--- a/spec/requests/admin/comments_update_spec.rb
+++ b/spec/requests/admin/comments_update_spec.rb
@@ -28,6 +28,20 @@ RSpec.describe "Admin::Comments 更新系", type: :request do
           expect(comment.reload.hidden).to be false
         end
       end
+      context "管理者" do
+        before do
+          sign_in admin
+        end
+  
+        it "コメントを非表示にできる" do
+          patch hide_admin_comment_path(comment)
+  
+          expect(response).to have_http_status(:found)
+          expect(response).to redirect_to(admin_comments_path)
+          expect(comment.reload.hidden).to be true
+        end
+      end
+    end
 
 
     end

--- a/spec/requests/admin/comments_update_spec.rb
+++ b/spec/requests/admin/comments_update_spec.rb
@@ -97,6 +97,19 @@ RSpec.describe "Admin::Comments 更新系", type: :request do
           expect(comment1.reload.hidden).to be true
           expect(comment2.reload.hidden).to be true
         end
-
+        it "複数コメントをまとめて再表示できる" do
+          comment1.update!(hidden: true)
+          comment2.update!(hidden: true)
+  
+          patch bulk_admin_comments_path, params: {
+            comment_ids: [comment1.id, comment2.id],
+            bulk_action: "show"
+          }
+  
+          expect(response).to have_http_status(:found)
+          expect(response).to redirect_to(admin_comments_path)
+          expect(comment1.reload.hidden).to be false
+          expect(comment2.reload.hidden).to be false
+        end
 
     end

--- a/spec/requests/admin/comments_update_spec.rb
+++ b/spec/requests/admin/comments_update_spec.rb
@@ -135,18 +135,6 @@ RSpec.describe "Admin::Comments 更新系", type: :request do
           expect(comment1.reload.hidden).to be false
           expect(comment2.reload.hidden).to be false
         end
-        it "対象が未選択の場合、コメントは変更されない" do
-          expect {
-            patch bulk_admin_comments_path, params: {
-              comment_ids: [],
-              bulk_action: "hide"
-            }
-          }.not_to change(Comment, :count)
-  
-          expect(response).to have_http_status(:found)
-          expect(response).to redirect_to(admin_comments_path)
-          expect(comment1.reload.hidden).to be false
-          expect(comment2.reload.hidden).to be false
-        end
+
 
     end

--- a/spec/requests/admin/comments_update_spec.rb
+++ b/spec/requests/admin/comments_update_spec.rb
@@ -111,5 +111,16 @@ RSpec.describe "Admin::Comments 更新系", type: :request do
           expect(comment1.reload.hidden).to be false
           expect(comment2.reload.hidden).to be false
         end
+        it "複数コメントをまとめて削除できる" do
+          expect {
+            patch bulk_admin_comments_path, params: {
+              comment_ids: [comment1.id, comment2.id],
+              bulk_action: "delete"
+            }
+          }.to change(Comment, :count).by(-2)
+  
+          expect(response).to have_http_status(:found)
+          expect(response).to redirect_to(admin_comments_path)
+        end
 
     end

--- a/spec/requests/admin/comments_update_spec.rb
+++ b/spec/requests/admin/comments_update_spec.rb
@@ -59,6 +59,24 @@ RSpec.describe "Admin::Comments 更新系", type: :request do
         end
       end
     end
+    describe "DELETE /admin/comments/:id" do
+      let!(:comment) { create(:comment, recipe: recipe, user: user) }
+  
+      context "管理者" do
+        before do
+          sign_in admin
+        end
+  
+        it "コメントを削除できる" do
+          expect {
+            delete admin_comment_path(comment)
+          }.to change(Comment, :count).by(-1)
+  
+          expect(response).to have_http_status(:found)
+          expect(response).to redirect_to(admin_comments_path)
+        end
+      end
+    end
 
 
     end

--- a/spec/requests/admin/comments_update_spec.rb
+++ b/spec/requests/admin/comments_update_spec.rb
@@ -77,6 +77,26 @@ RSpec.describe "Admin::Comments 更新系", type: :request do
         end
       end
     end
+    describe "PATCH /admin/comments/bulk" do
+      let!(:comment1) { create(:comment, recipe: recipe, user: user, hidden: false) }
+      let!(:comment2) { create(:comment, recipe: recipe, user: user, hidden: false) }
+  
+      context "管理者" do
+        before do
+          sign_in admin
+        end
+  
+        it "複数コメントをまとめて非表示にできる" do
+          patch bulk_admin_comments_path, params: {
+            comment_ids: [comment1.id, comment2.id],
+            bulk_action: "hide"
+          }
+  
+          expect(response).to have_http_status(:found)
+          expect(response).to redirect_to(admin_comments_path)
+          expect(comment1.reload.hidden).to be true
+          expect(comment2.reload.hidden).to be true
+        end
 
 
     end

--- a/spec/requests/admin/comments_update_spec.rb
+++ b/spec/requests/admin/comments_update_spec.rb
@@ -1,0 +1,10 @@
+RSpec.describe "Admin::Comments 更新系", type: :request do
+  let(:admin) { create(:user, :admin) }
+  let(:user)  { create(:user) }
+  let(:recipe) { create(:recipe, user: user) }
+
+  describe "PATCH /admin/comments/:id/hide" do
+    let!(:comment) { create(:comment, recipe: recipe, user: user, hidden: false) }
+
+      end
+    end

--- a/spec/requests/admin/comments_update_spec.rb
+++ b/spec/requests/admin/comments_update_spec.rb
@@ -135,5 +135,18 @@ RSpec.describe "Admin::Comments 更新系", type: :request do
           expect(comment1.reload.hidden).to be false
           expect(comment2.reload.hidden).to be false
         end
+        it "対象が未選択の場合、コメントは変更されない" do
+          expect {
+            patch bulk_admin_comments_path, params: {
+              comment_ids: [],
+              bulk_action: "hide"
+            }
+          }.not_to change(Comment, :count)
+  
+          expect(response).to have_http_status(:found)
+          expect(response).to redirect_to(admin_comments_path)
+          expect(comment1.reload.hidden).to be false
+          expect(comment2.reload.hidden).to be false
+        end
 
     end

--- a/spec/requests/admin/comments_update_spec.rb
+++ b/spec/requests/admin/comments_update_spec.rb
@@ -15,4 +15,19 @@ RSpec.describe "Admin::Comments 更新系", type: :request do
           expect(response).to redirect_to(new_user_session_path)
         end
       end
+      context "一般ユーザー" do
+        before do
+          sign_in user
+        end
+  
+        it "rootへリダイレクトされ、コメントは非表示にならない" do
+          patch hide_admin_comment_path(comment)
+  
+          expect(response).to have_http_status(:found)
+          expect(response).to redirect_to(root_path)
+          expect(comment.reload.hidden).to be false
+        end
+      end
+
+
     end


### PR DESCRIPTION
## 追加したテスト内容

- 未ログインの場合、コメントを非表示にできないことを確認
- 一般ユーザーの場合、コメントを非表示にできないことを確認
- 管理者の場合、コメントを非表示にできることを確認
- 管理者の場合、コメントを再表示できることを確認
- 管理者の場合、コメントを削除できることを確認
- 管理者が複数コメントをまとめて非表示にできることを確認
- 管理者が複数コメントをまとめて再表示できることを確認
- 管理者が複数コメントをまとめて削除できることを確認
- 対象コメントが未選択の場合、変更されないことを確認
- アクション未選択の場合、変更されないことを確認